### PR TITLE
feat: Add summary tab showing per-person balance breakdown (closes #19)

### DIFF
--- a/src/app/group/[groupId]/components/Tab.tsx
+++ b/src/app/group/[groupId]/components/Tab.tsx
@@ -1,11 +1,13 @@
 import { SegmentedControl, VisuallyHidden, rem } from "@mantine/core";
 import { IconListLetters } from "@tabler/icons-react";
 import { IconChartCandle } from "@tabler/icons-react";
+import { IconUsers } from "@tabler/icons-react";
 import React from "react";
 
 export enum TabType {
   Transactions = "transactions",
   Overview = "overview",
+  Summary = "summary",
 }
 
 type TabProps = {
@@ -40,6 +42,15 @@ const Tab = ({ selectedTab, setSelectedTab }: TabProps) => {
             <>
               <IconChartCandle {...iconProps} />
               <VisuallyHidden>Overview</VisuallyHidden>
+            </>
+          ),
+        },
+        {
+          value: TabType.Summary,
+          label: (
+            <>
+              <IconUsers {...iconProps} />
+              <VisuallyHidden>Summary</VisuallyHidden>
             </>
           ),
         },

--- a/src/app/group/[groupId]/components/TabSummary.tsx
+++ b/src/app/group/[groupId]/components/TabSummary.tsx
@@ -56,7 +56,7 @@ const TabSummary = () => {
     if (toEntry) toEntry.net += debt.amount;
   });
 
-  const sorted = [...balanceMap.values()].sort((a, b) => b.net - a.net);
+  const sorted = Array.from(balanceMap.values()).sort((a, b) => b.net - a.net);
 
   const isSettled = sorted.every((e) => Math.abs(e.net) < 0.01);
 

--- a/src/app/group/[groupId]/components/TabSummary.tsx
+++ b/src/app/group/[groupId]/components/TabSummary.tsx
@@ -1,0 +1,129 @@
+import {
+  Avatar,
+  Center,
+  NavLink,
+  NumberFormatter,
+  Skeleton,
+  Stack,
+  Text,
+  Title,
+  rem,
+} from "@mantine/core";
+import { useParams } from "next/navigation";
+import { useDebts, useTotalSpend } from "@/api";
+import { Participant } from "@/types";
+
+const TabSummary = () => {
+  const { groupId } = useParams<{ groupId: string }>();
+  const { data: debts, isPending: debtsPending } = useDebts(groupId);
+  const { data: totalSpendData, isPending: groupPending } =
+    useTotalSpend(groupId);
+
+  if (debtsPending || groupPending) {
+    return (
+      <Stack>
+        <Skeleton height={rem(50)} radius="md" my={rem(10)} />
+        <Skeleton height={rem(30)} radius="md" />
+        <Skeleton height={rem(30)} radius="md" />
+        <Skeleton height={rem(30)} radius="md" />
+        <Skeleton height={rem(30)} radius="md" />
+      </Stack>
+    );
+  }
+
+  if (!debts || !totalSpendData) return null;
+
+  const participants =
+    totalSpendData.expand.groupInfo.expand?.participants ?? [];
+
+  // Compute net balance per participant from simplified debts
+  // positive net = this person is owed money
+  // negative net = this person owes money
+  const balanceMap = new Map<
+    string,
+    { participant: Participant; net: number }
+  >();
+
+  participants.forEach((p) => {
+    balanceMap.set(p.id!, { participant: p, net: 0 });
+  });
+
+  debts.forEach((debt) => {
+    const fromEntry = balanceMap.get(debt.fromPerson.id!);
+    if (fromEntry) fromEntry.net -= debt.amount;
+
+    const toEntry = balanceMap.get(debt.toPerson.id!);
+    if (toEntry) toEntry.net += debt.amount;
+  });
+
+  const sorted = [...balanceMap.values()].sort((a, b) => b.net - a.net);
+
+  const isSettled = sorted.every((e) => Math.abs(e.net) < 0.01);
+
+  return (
+    <>
+      <Text fw={500}>Balance per Person</Text>
+      <Stack mb={100} gap="xs">
+        {sorted.length === 0 ? (
+          <Center p="lg">
+            <Text c="dimmed" size="sm">
+              No participants
+            </Text>
+          </Center>
+        ) : isSettled ? (
+          <Center p="lg">
+            <Text c="dimmed" size="sm">
+              All settled up
+            </Text>
+          </Center>
+        ) : (
+          sorted.map(({ participant, net }) => {
+            const isOwed = net > 0.01;
+            const isOwes = net < -0.01;
+            const color = isOwed ? "green" : isOwes ? "red" : "dimmed";
+
+            return (
+              <NavLink
+                key={participant.id}
+                label={participant.name}
+                leftSection={
+                  <Avatar size={rem(40)} radius={rem(40)}>
+                    <Title order={3}>{participant.avatar.emoji}</Title>
+                  </Avatar>
+                }
+                rightSection={
+                  <Text fw={600} c={color} size="sm">
+                    {isOwed || (!isOwed && !isOwes) ? (
+                      <NumberFormatter
+                        prefix={isOwed ? "+ " : ""}
+                        suffix=" €"
+                        value={Math.abs(net)}
+                        thousandSeparator="."
+                        decimalSeparator=","
+                        decimalScale={2}
+                        fixedDecimalScale
+                      />
+                    ) : (
+                      <NumberFormatter
+                        prefix="- "
+                        suffix=" €"
+                        value={Math.abs(net)}
+                        thousandSeparator="."
+                        decimalSeparator=","
+                        decimalScale={2}
+                        fixedDecimalScale
+                      />
+                    )}
+                  </Text>
+                }
+                styles={{ root: { borderRadius: rem(8) } }}
+              />
+            );
+          })
+        )}
+      </Stack>
+    </>
+  );
+};
+
+export default TabSummary;

--- a/src/app/group/[groupId]/components/TopSummary.tsx
+++ b/src/app/group/[groupId]/components/TopSummary.tsx
@@ -86,6 +86,19 @@ const TopSummary = ({ selectedTab, groupData }: TopSummaryProps) => {
             </Center>
           </Stack>
         )}
+        {selectedTab === TabType.Summary && (
+          <Stack gap="xs" h={rem(120)} justify="center">
+            <Center>
+              <Text>Summary</Text>
+            </Center>
+            <Center>
+              <Text c="dimmed" size="sm">
+                {data.expand.groupInfo.expand?.participants?.length ?? 0}{" "}
+                participants
+              </Text>
+            </Center>
+          </Stack>
+        )}
       </Stack>
     );
   }

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -5,6 +5,7 @@ import Tab, { TabType } from "./components/Tab";
 import TopSummary from "./components/TopSummary";
 import TabOverview from "./components/TabOverview";
 import TabTransactions from "./components/TabTransactions";
+import TabSummary from "./components/TabSummary";
 import { SPLTIconSmall } from "@/components/SPLTIcon";
 import { useParams } from "next/navigation";
 import { useTotalSpend } from "@/api";
@@ -41,6 +42,7 @@ const GroupPage = () => {
           {selectedTab === TabType.Transactions && (
             <TabTransactions groupData={groupData} />
           )}
+          {selectedTab === TabType.Summary && <TabSummary />}
         </Stack>
         <MadeWithLove />
       </Container>


### PR DESCRIPTION
Adds a new "Summary" tab to the group page that shows each participant's
net balance after debt simplification — green for money owed to them,
red for money they owe, dimmed when settled.

- TabSummary.tsx: aggregates simplified debts from useDebts() and
  participant list from useTotalSpend() to compute net balance per person,
  sorted highest-owed first
- Tab.tsx: adds TabType.Summary with IconUsers icon
- TopSummary.tsx: adds header for the Summary tab (participant count)
- page.tsx: wires up TabSummary rendering

https://claude.ai/code/session_01TYZP4zF1jQk8KNThTfqzvN