### PR TITLE
Add validation for split amount distribution in transactions

### DIFF
--- a/db/pb_hooks/main.pb.js
+++ b/db/pb_hooks/main.pb.js
@@ -53,6 +53,7 @@ routerAdd("GET", "/api/splt/expense", (c) => {
 
   let amountPerPerson = 0;
   let participantAmounts = {}; // { participantId: amount } — populated for part/amount types
+  let rawSplits = []; // [{ participantId, part, amount }] — original split records
 
   if (splitType === "part" || splitType === "amount") {
     const splits = $app.dao().findRecordsByFilter(
@@ -64,21 +65,21 @@ routerAdd("GET", "/api/splt/expense", (c) => {
       { expenseId: expenseId }
     );
 
+    splits.forEach((split) => {
+      const s = JSON.parse(JSON.stringify(split));
+      rawSplits.push({ participantId: s.participantId, part: s.part, amount: s.amount });
+    });
+
     if (splitType === "part") {
       let totalParts = 0;
-      splits.forEach((split) => {
-        const s = JSON.parse(JSON.stringify(split));
-        totalParts += s.part || 0;
-      });
-      splits.forEach((split) => {
-        const s = JSON.parse(JSON.stringify(split));
+      rawSplits.forEach((s) => { totalParts += s.part || 0; });
+      rawSplits.forEach((s) => {
         participantAmounts[s.participantId] =
           totalParts > 0 ? totalAmount * ((s.part || 0) / totalParts) : 0;
       });
     } else {
       // amount — use stored value directly
-      splits.forEach((split) => {
-        const s = JSON.parse(JSON.stringify(split));
+      rawSplits.forEach((s) => {
         participantAmounts[s.participantId] = s.amount || 0;
       });
     }
@@ -94,7 +95,7 @@ routerAdd("GET", "/api/splt/expense", (c) => {
       : totalAmount / numExpenseParticipants;
   }
 
-  return c.json(200, { ...expense, amountPerPerson, participantAmounts });
+  return c.json(200, { ...expense, amountPerPerson, participantAmounts, splits: rawSplits });
 });
 
 // POST /api/splt/expense — create expense + splits atomically

--- a/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
+++ b/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
@@ -517,16 +517,25 @@ const PageSetSplit = ({
           </Combobox>
 
           {form.values.splitType === SplitType.Amount && (
-            <Group justify="space-between" mt={12} px={4}>
-              <Text size="sm" c="dimmed">Remaining</Text>
-              <Text
-                size="sm"
-                fw={500}
-                c={calculateRemainingAmount() < -0.001 ? "red" : calculateRemainingAmount() < 0.001 ? "green" : undefined}
-              >
-                {EuroNumberFormatter({ value: calculateRemainingAmount() })}
-              </Text>
-            </Group>
+            <>
+              <Group justify="space-between" mt={12} px={4}>
+                <Text size="sm" c="dimmed">Remaining</Text>
+                <Text
+                  size="sm"
+                  fw={500}
+                  c={calculateRemainingAmount() < -0.001 ? "red" : calculateRemainingAmount() < 0.001 ? "green" : undefined}
+                >
+                  {EuroNumberFormatter({ value: calculateRemainingAmount() })}
+                </Text>
+              </Group>
+              {form.errors.splitAmountError && (
+                <Center mt={4}>
+                  <Text c="red" size="sm">
+                    {form.errors.splitAmountError}
+                  </Text>
+                </Center>
+              )}
+            </>
           )}
         </Stack>
       </ScrollArea>

--- a/src/components/AddEditTransactionModal/index.tsx
+++ b/src/components/AddEditTransactionModal/index.tsx
@@ -130,14 +130,23 @@ const AddEditTransactionModal = ({
     },
   });
 
-  const [splitData, setSplitData] = useState<SplitData[]>([
-    {
-      expenseId: "1234",
-      participantId: "1234",
-      part: 0,
-      amount: 0,
-    },
-  ]);
+  const [splitData, setSplitData] = useState<SplitData[]>(
+    isEdit && expenseData && expenseData.splits && expenseData.splits.length > 0
+      ? expenseData.splits.map((s) => ({
+          expenseId: expenseData.id,
+          participantId: s.participantId,
+          part: s.part,
+          amount: s.amount,
+        }))
+      : [
+          {
+            expenseId: "",
+            participantId: "",
+            part: 0,
+            amount: 0,
+          },
+        ]
+  );
 
   return (
     <form onSubmit={form.onSubmit((values) => console.log(values))}>

--- a/src/components/AddEditTransactionModal/index.tsx
+++ b/src/components/AddEditTransactionModal/index.tsx
@@ -102,11 +102,26 @@ const AddEditTransactionModal = ({
       }
 
       if (page === 2) {
+        let splitAmountError: string | null = null;
+        if (values.splitType === SplitType.Amount) {
+          const totalEntered = splitData.reduce(
+            (sum, split) => sum + (split.amount || 0),
+            0
+          );
+          const remaining = (values.amount || 0) - totalEntered;
+          if (remaining > 0.001) {
+            splitAmountError = "Remaining amount must be fully distributed";
+          } else if (remaining < -0.001) {
+            splitAmountError = "Total split amount exceeds the transaction amount";
+          }
+        }
+
         return {
           participants:
             values.participants.length < 1
               ? "Participants must include at least 1 person"
               : null,
+          splitAmountError,
         };
       }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,6 +89,7 @@ export type ExpenseTransactionData = {
   amount: number;
   amountPerPerson?: number;
   participantAmounts?: Record<string, number>;
+  splits?: Array<{ participantId: string; part: number | null; amount: number | null }>;
   avatar: StoreEmojiData;
   created: string;
   expand: {


### PR DESCRIPTION
## Summary
Added validation to ensure that when splitting a transaction by amount, the split amounts must exactly match the transaction total without remainder.

## Key Changes
- **Validation Logic**: Added split amount validation in `AddEditTransactionModal` that checks:
  - All amount splits must sum to exactly the transaction amount (within 0.001 tolerance)
  - Displays error if remaining amount is undistributed (> 0.001)
  - Displays error if total split amount exceeds transaction amount (< -0.001)

- **Error Display**: Updated `PageSetSplit` component to display the split amount validation error message below the "Remaining" amount indicator when validation fails

## Implementation Details
- Validation only runs when `splitType === SplitType.Amount`
- Uses a tolerance of 0.001 to handle floating-point precision issues
- Error messages are user-friendly and indicate the specific issue (undistributed vs. overspent)
- Error state is stored in `form.errors.splitAmountError` and displayed in a centered red text component

https://claude.ai/code/session_019y1u3vguQxhKaudoLo63q6