### PR TITLE
feat: local user selection with payment details

### DIFF
--- a/.serena/memories/ui/mantine-styling.md
+++ b/.serena/memories/ui/mantine-styling.md
@@ -1,0 +1,18 @@
+# Mantine Styling Priority
+
+Always use component props before `styles` or inline CSS.
+
+1. **Component props first**: `radius`, `color`, `variant`, `size`, `gap`, `p`, `m`, etc.
+2. **`styles` prop**: only when no component prop exists for the property
+3. **CSS variables**: `var(--mantine-radius-xl)` only as last resort inside `styles`
+
+## Example
+```tsx
+// Bad
+<Menu styles={{ dropdown: { borderRadius: "var(--mantine-radius-md)" } }} />
+
+// Good
+<Menu radius="md" />
+```
+
+Check Mantine docs for available props before reaching for `styles`.

--- a/.serena/memories/ui/modal-pattern.md
+++ b/.serena/memories/ui/modal-pattern.md
@@ -1,0 +1,32 @@
+# Modal Pattern
+
+## Custom multi-step modal: `src/components/Modal.tsx`
+Use for multi-step form flows with a trigger button. Requires: `form`, `page`, `pageHandler`, `maxPage`, `confirmPage`, `onConfirmClick`, `button` props. Handles carousel pagination, form validation per page, and mobile/desktop layout automatically.
+
+## Simple modals (single page, programmatically opened)
+Do NOT use Mantine's `Modal` directly. Use `Modal.Root` compound components with this exact responsive pattern:
+
+```tsx
+import { useMediaQuery } from "@mantine/hooks";
+import { Modal } from "@mantine/core";
+
+const isMobile = useMediaQuery("(max-width: 50em)") || false;
+
+<Modal.Root
+  opened={opened}
+  onClose={onClose}
+  fullScreen={isMobile}
+  transitionProps={{ transition: "slide-up", duration: 200 }}
+  centered
+>
+  <Modal.Overlay />
+  <Modal.Content radius={isMobile ? 0 : "lg"}>
+    <Modal.Header>...</Modal.Header>
+    <Modal.Body>...</Modal.Body>
+  </Modal.Content>
+</Modal.Root>
+```
+
+This matches the responsive behaviour of `Modal.tsx`: full-screen slide-up on mobile, centered dialog on desktop.
+
+## Example: `src/components/UserSelectionModal.tsx`

--- a/src/app/group/[groupId]/components/Tab.tsx
+++ b/src/app/group/[groupId]/components/Tab.tsx
@@ -1,11 +1,11 @@
 import { SegmentedControl, VisuallyHidden, rem } from "@mantine/core";
-import { IconListLetters } from "@tabler/icons-react";
-import { IconChartCandle } from "@tabler/icons-react";
+import { IconListLetters, IconChartCandle, IconCoin } from "@tabler/icons-react";
 import React from "react";
 
 export enum TabType {
   Transactions = "transactions",
   Overview = "overview",
+  TotalSpending = "totalSpending",
 }
 
 type TabProps = {
@@ -40,6 +40,15 @@ const Tab = ({ selectedTab, setSelectedTab }: TabProps) => {
             <>
               <IconChartCandle {...iconProps} />
               <VisuallyHidden>Overview</VisuallyHidden>
+            </>
+          ),
+        },
+        {
+          value: TabType.TotalSpending,
+          label: (
+            <>
+              <IconCoin {...iconProps} />
+              <VisuallyHidden>Total Spending</VisuallyHidden>
             </>
           ),
         },

--- a/src/app/group/[groupId]/components/TabOverview.tsx
+++ b/src/app/group/[groupId]/components/TabOverview.tsx
@@ -1,29 +1,17 @@
-import {
-  Avatar,
-  AvatarGroup,
-  Center,
-  NavLink,
-  NumberFormatter,
-  Skeleton,
-  Stack,
-  Text,
-  Title,
-rem,
-} from "@mantine/core";
+import { Center, Skeleton, Stack, Text, rem } from "@mantine/core";
 import React from "react";
-import { GroupData } from "@/types";
 import { useDebts } from "@/api";
 import { useParams } from "next/navigation";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
 import ViewDebtModal from "@/components/ViewDebtModal";
 
 type TabOverviewProps = {
-  // groupData: GroupData;
+  localUserId?: string | null;
 };
 
-const TabOverview = ({}: TabOverviewProps) => {
+const TabOverview = ({ localUserId }: TabOverviewProps) => {
   const { groupId } = useParams<{ groupId: string }>();
-  const { data, isPending, error } = useDebts(groupId);
+  const { data, isPending } = useDebts(groupId);
+
   if (isPending) {
     return (
       <Stack>
@@ -32,30 +20,51 @@ const TabOverview = ({}: TabOverviewProps) => {
         <Skeleton height={rem(30)} radius="md" />
         <Skeleton height={rem(30)} radius="md" />
         <Skeleton height={rem(30)} radius="md" />
-        
       </Stack>
     );
   }
+
   if (data) {
+    const myDebts = localUserId
+      ? data.filter((d) => d.fromPerson.id === localUserId)
+      : [];
+    const owedToMe = localUserId
+      ? data.filter((d) => d.toPerson.id === localUserId)
+      : [];
+    const otherDebts = localUserId
+      ? data.filter(
+          (d) =>
+            d.fromPerson.id !== localUserId && d.toPerson.id !== localUserId
+        )
+      : data;
+
     return (
       <>
         <Text fw={500}>Debts</Text>
         <Stack mb={100} gap="xs">
-          {data.length > 0 ? (
-            data.map((debt, index) => <ViewDebtModal key={index} debt={debt} />)
-          ) : (
-            <Center
-              p="lg"
-              // c="dimmed" style={{ border: "1px dashed" }}
-            >
+          {data.length === 0 ? (
+            <Center p="lg">
               <Text c="dimmed" size="sm">
                 No debts
               </Text>
             </Center>
+          ) : (
+            <>
+              {myDebts.map((debt, i) => (
+                <ViewDebtModal key={`my-${i}`} debt={debt} />
+              ))}
+              {owedToMe.map((debt, i) => (
+                <ViewDebtModal key={`owed-${i}`} debt={debt} />
+              ))}
+              {otherDebts.map((debt, i) => (
+                <ViewDebtModal key={`other-${i}`} debt={debt} />
+              ))}
+            </>
           )}
         </Stack>
       </>
     );
   }
 };
+
 export default TabOverview;

--- a/src/app/group/[groupId]/components/TabTotalSpending.tsx
+++ b/src/app/group/[groupId]/components/TabTotalSpending.tsx
@@ -1,0 +1,202 @@
+import {
+  ActionIcon,
+  Avatar,
+  AvatarGroup,
+  Center,
+  Modal,
+  NavLink,
+  ScrollArea,
+  Skeleton,
+  Stack,
+  Text,
+  Title,
+  rem,
+} from "@mantine/core";
+import { useParams } from "next/navigation";
+import { useTransactions } from "@/api";
+import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { ExpenseTransactionData, Participant, TotalSpendData } from "@/types";
+import { UseQueryResult } from "@tanstack/react-query";
+import { useDisclosure, useMediaQuery, useViewportSize } from "@mantine/hooks";
+import UserAvatar from "@/components/UserAvatar";
+import { useState } from "react";
+import { IconChevronLeft } from "@tabler/icons-react";
+import { DateToCalendar } from "@/utils/date";
+
+type TabTotalSpendingProps = {
+  groupData: UseQueryResult<TotalSpendData, Error>;
+  localUserId?: string | null;
+};
+
+type SelectedPerson = {
+  participant: Participant;
+  expenses: ExpenseTransactionData[];
+  total: number;
+};
+
+const MAX_AVATARS = 5;
+
+const TabTotalSpending = ({ groupData, localUserId }: TabTotalSpendingProps) => {
+  const { groupId } = useParams<{ groupId: string }>();
+  const { data, isPending } = useTransactions(groupId);
+  const [opened, { open, close }] = useDisclosure(false);
+  const [selected, setSelected] = useState<SelectedPerson | null>(null);
+  const isMobile = useMediaQuery("(max-width: 50em)") || false;
+  const { height } = useViewportSize();
+  const modalHeight = isMobile ? rem(height - 100) : rem(500);
+
+  const handleOpen = (person: SelectedPerson) => {
+    setSelected(person);
+    open();
+  };
+
+  if (isPending || groupData.isPending) {
+    return (
+      <Stack>
+        <Skeleton height={rem(50)} radius="md" my={rem(10)} />
+        <Skeleton height={rem(30)} radius="md" />
+        <Skeleton height={rem(30)} radius="md" />
+        <Skeleton height={rem(30)} radius="md" />
+      </Stack>
+    );
+  }
+
+  if (data && groupData.data) {
+    const participants = groupData.data.expand.groupInfo.expand.participants;
+
+    const expensesByPayer: Record<string, ExpenseTransactionData[]> = {};
+    const totals: Record<string, number> = {};
+
+    data.transactions
+      .filter((t) => t.collectionName === "expenses")
+      .forEach((t) => {
+        const expense = t as ExpenseTransactionData;
+        const id = expense.expand.paidBy.id!;
+        totals[id] = (totals[id] ?? 0) + expense.amount;
+        expensesByPayer[id] = [...(expensesByPayer[id] ?? []), expense];
+      });
+
+    const rows = participants
+      .map((p: Participant) => ({
+        participant: p,
+        total: totals[p.id!] ?? 0,
+        expenses: expensesByPayer[p.id!] ?? [],
+      }))
+      .sort((a, b) => {
+        if (a.participant.id === localUserId) return -1;
+        if (b.participant.id === localUserId) return 1;
+        return b.total - a.total;
+      });
+
+    return (
+      <>
+        <Modal.Root
+          opened={opened}
+          onClose={close}
+          fullScreen={isMobile}
+          transitionProps={{ transition: "pop", duration: 200 }}
+          centered
+        >
+          <Modal.Overlay />
+          <Modal.Content radius={isMobile ? 0 : "lg"}>
+            <Modal.Header>
+              <ActionIcon variant="transparent" color="gray" onClick={close}>
+                <IconChevronLeft style={{ width: "70%", height: "70%" }} stroke={1.5} />
+              </ActionIcon>
+            </Modal.Header>
+            <Modal.Body>
+              {selected && (
+                <ScrollArea h={modalHeight}>
+                <Stack>
+                  <Center>
+                    <Stack gap={rem(4)} align="center">
+                      <UserAvatar size="lg">
+                        <Title order={2}>{selected.participant.avatar.emoji}</Title>
+                      </UserAvatar>
+                      <Text fw={600}>{selected.participant.name}</Text>
+                      <Text size="sm" c="dimmed">
+                        <EuroNumberFormatter value={selected.total} /> paid
+                      </Text>
+                    </Stack>
+                  </Center>
+                  <Stack gap="xs" mt="sm">
+                    {selected.expenses.length === 0 ? (
+                      <Center p="lg">
+                        <Text c="dimmed" size="sm">No transaction</Text>
+                      </Center>
+                    ) : (
+                      selected.expenses
+                        .sort((a, b) => Date.parse(b.transactionDateTime) - Date.parse(a.transactionDateTime))
+                        .map((e) => (
+                          <NavLink
+                            key={e.id}
+                            label={e.name}
+                            description={DateToCalendar({ date: e.transactionDateTime })}
+                            leftSection={
+                              <Avatar size="sm" radius="xl">
+                                {e.avatar.emoji}
+                              </Avatar>
+                            }
+                            rightSection={
+                              <Text fw={500} size="sm">
+                                <EuroNumberFormatter value={e.amount} />
+                              </Text>
+                            }
+                            style={{ pointerEvents: "none" }}
+                          />
+                        ))
+                    )}
+                  </Stack>
+                </Stack>
+                </ScrollArea>
+              )}
+            </Modal.Body>
+          </Modal.Content>
+        </Modal.Root>
+
+        <Text fw={500}>Spending</Text>
+        <Stack mb={100} gap="xs">
+          {rows.map(({ participant, total, expenses }) => (
+            <NavLink
+              key={participant.id}
+              label={participant.name}
+              description={<EuroNumberFormatter value={total} />}
+              leftSection={
+                <UserAvatar size="md">
+                  <Title order={3}>{participant.avatar.emoji}</Title>
+                </UserAvatar>
+              }
+              rightSection={
+                expenses.length > 0 ? (
+                  <AvatarGroup spacing="xs">
+                    {expenses.slice(0, MAX_AVATARS).map((e) => (
+                      <Avatar key={e.id} size="sm" radius="xl">
+                        {e.avatar.emoji}
+                      </Avatar>
+                    ))}
+                    {expenses.length > MAX_AVATARS && (
+                      <Avatar size="sm" radius="xl">
+                        +{expenses.length - MAX_AVATARS}
+                      </Avatar>
+                    )}
+                  </AvatarGroup>
+                ) : null
+              }
+              fw={participant.id === localUserId ? 700 : 400}
+              onClick={() => handleOpen({ participant, total, expenses })}
+            />
+          ))}
+          {rows.length === 0 && (
+            <Center p="lg">
+              <Text c="dimmed" size="sm">
+                No spending yet
+              </Text>
+            </Center>
+          )}
+        </Stack>
+      </>
+    );
+  }
+};
+
+export default TabTotalSpending;

--- a/src/app/group/[groupId]/components/TabTransactions.tsx
+++ b/src/app/group/[groupId]/components/TabTransactions.tsx
@@ -12,6 +12,7 @@ import {
   useMantineColorScheme,
 } from "@mantine/core";
 import { TotalSpendData } from "@/types";
+import UserAvatar from "@/components/UserAvatar";
 import { DateToCalendar } from "@/utils/date";
 import { useTransactions } from "@/api";
 import { useParams, useRouter } from "next/navigation";
@@ -21,10 +22,10 @@ import { UseQueryResult } from "@tanstack/react-query";
 
 type TabTransactionsProps = {
   groupData: UseQueryResult<TotalSpendData, Error>;
-  // groupTransactionData: TransactionsData[];
+  localUserId?: string | null;
 };
 
-const TabTransactions = ({ groupData }: TabTransactionsProps) => {
+const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
   const { colorScheme } = useMantineColorScheme();
   const router = useRouter();
   const { groupId } = useParams<{ groupId: string }>();
@@ -54,6 +55,7 @@ const TabTransactions = ({ groupData }: TabTransactionsProps) => {
           {groupData.data && (
             <AddEditTransactionModal
               groupData={groupData.data.expand.groupInfo}
+              localUserId={localUserId}
               button={
                 <Text fw={600} c="blue">
                   Add
@@ -119,14 +121,14 @@ const TabTransactions = ({ groupData }: TabTransactionsProps) => {
                     date: trans.transactionDateTime,
                   })}
                   leftSection={
-                    <Avatar>
+                    <UserAvatar>
                       <Title style={{ transform: "translate(2px)" }} order={4}>
                         {trans.expand.fromPerson.avatar.emoji}
                       </Title>
                       <Title style={{ transform: "translate(-2px)" }} order={4}>
                         {trans.expand.toPerson.avatar.emoji}
                       </Title>
-                    </Avatar>
+                    </UserAvatar>
                   }
                   rightSection={
                     <Title order={5}>

--- a/src/app/group/[groupId]/components/TabTransactions.tsx
+++ b/src/app/group/[groupId]/components/TabTransactions.tsx
@@ -87,6 +87,7 @@ const TabTransactions = ({ groupData }: TabTransactionsProps) => {
                       offset={3}
                       position="bottom-end"
                       size={22}
+                      zIndex={1}
                       // withBorder
                       label={
                         <Text size="xs">

--- a/src/app/group/[groupId]/components/TabTransactions.tsx
+++ b/src/app/group/[groupId]/components/TabTransactions.tsx
@@ -43,10 +43,11 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
   }
   if (data) {
     console.log(data);
-    data.transactions.sort((a, b) => {
-      return (
-        Date.parse(b.transactionDateTime) - Date.parse(a.transactionDateTime)
-      );
+    const sortedTransactions = [...data.transactions].sort((a, b) => {
+      const diff =
+        Date.parse(b.transactionDateTime) - Date.parse(a.transactionDateTime);
+      if (diff !== 0) return diff;
+      return Date.parse(b.created) - Date.parse(a.created);
     });
     return (
       <>
@@ -64,7 +65,7 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
             />
           )}
         </Group>
-        {data.transactions?.length === 0 ? (
+        {sortedTransactions.length === 0 ? (
           <Center
             p="lg"
             // c="dimmed" style={{ border: "1px dashed" }}
@@ -75,7 +76,7 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
           </Center>
         ) : (
           <Stack mb={100} gap="xs">
-            {data.transactions?.map((trans, index) =>
+            {sortedTransactions.map((trans, index) =>
               trans.collectionName === "expenses" ? (
                 <NavLink
                   key={index}

--- a/src/app/group/[groupId]/components/TopSummary.tsx
+++ b/src/app/group/[groupId]/components/TopSummary.tsx
@@ -1,47 +1,55 @@
 import {
-  ActionIcon,
   Avatar,
-  AvatarGroup,
   Center,
-  NumberFormatter,
   Skeleton,
   Stack,
   Text,
   Title,
-  UnstyledButton,
   rem,
 } from "@mantine/core";
 import React from "react";
-import { GroupData, TotalSpendData } from "@/types";
-import { IconPlus } from "@tabler/icons-react";
-import { IconPencil } from "@tabler/icons-react";
+import { TotalSpendData } from "@/types";
 import { TabType } from "./Tab";
 import { useParams } from "next/navigation";
-// import { useGroup, useTotalSpend } from "@/api";
 import { UseQueryResult } from "@tanstack/react-query";
 import ListParticipantsModal from "@/components/ListParticipantsModal";
 import { EuroNumberFormatter } from "@/components/NumberFormatter";
 import EditGroupModal from "./EditGroupModal";
+import { useDebts } from "@/api";
 
 type TopSummaryProps = {
   groupData: UseQueryResult<TotalSpendData, Error>;
   selectedTab: string;
+  localUserId?: string | null;
 };
 
-const TopSummary = ({ selectedTab, groupData }: TopSummaryProps) => {
-  const { data, isPending, error } = groupData;
+const TopSummary = ({ selectedTab, groupData, localUserId }: TopSummaryProps) => {
+  const { groupId } = useParams<{ groupId: string }>();
+  const { data: debts } = useDebts(groupId);
+  const { data, isPending } = groupData;
+
+  const netBalance = (() => {
+    if (!debts || !localUserId) return null;
+    const owed = debts
+      .filter((d) => d.fromPerson.id === localUserId)
+      .reduce((s, d) => s + d.amount, 0);
+    const owedToMe = debts
+      .filter((d) => d.toPerson.id === localUserId)
+      .reduce((s, d) => s + d.amount, 0);
+    return owedToMe - owed;
+  })();
+
   if (isPending) {
     return (
       <Stack gap={0}>
-        {/* <Center> */}
         <Skeleton height={rem(100)} circle mb="sm" />
-        {/* </Center> */}
         <Skeleton height={rem(40)} radius="xl" mb="sm" />
         <Skeleton height={rem(20)} radius="xl" mb="sm" />
         <Skeleton height={rem(20)} radius="xl" mb="sm" />
       </Stack>
     );
   }
+
   if (data) {
     return (
       <Stack gap="xs">
@@ -52,6 +60,7 @@ const TopSummary = ({ selectedTab, groupData }: TopSummaryProps) => {
             </Title>
           </Avatar>
         </Center>
+
         {selectedTab === TabType.Transactions && (
           <Stack h={rem(120)}>
             <EditGroupModal
@@ -72,16 +81,50 @@ const TopSummary = ({ selectedTab, groupData }: TopSummaryProps) => {
             </Center>
           </Stack>
         )}
+
         {selectedTab === TabType.Overview && (
           <Stack gap="xs" h={rem(120)} justify="center">
+            {netBalance !== null ? (
+              <>
+                <Center>
+                  <Text c="dimmed">Your balance</Text>
+                </Center>
+                <Center>
+                  <Title
+                    order={2}
+                    c={netBalance > 0 ? "green" : netBalance < 0 ? "red" : "dimmed"}
+                  >
+                    <EuroNumberFormatter value={Math.abs(netBalance)} />
+                  </Title>
+                </Center>
+                <Center>
+                  <Text size="sm" c="dimmed">
+                    {netBalance > 0
+                      ? "you are owed"
+                      : netBalance < 0
+                      ? "you owe"
+                      : "all settled"}
+                  </Text>
+                </Center>
+              </>
+            ) : (
+              <>
+                <Center>
+                  <Text c="dimmed">Debts</Text>
+                </Center>
+              </>
+            )}
+          </Stack>
+        )}
+
+        {selectedTab === TabType.TotalSpending && (
+          <Stack gap="xs" h={rem(120)} justify="center">
             <Center>
-              <Text>Total Spending</Text>
+              <Text c="dimmed">Total Spending</Text>
             </Center>
             <Center>
               <Title order={2}>
-                <EuroNumberFormatter
-                  value={data.sumExpenses ? data.sumExpenses : 0}
-                />
+                <EuroNumberFormatter value={data.sumExpenses ?? 0} />
               </Title>
             </Center>
           </Stack>

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -5,6 +5,7 @@ import Tab, { TabType } from "./components/Tab";
 import TopSummary from "./components/TopSummary";
 import TabOverview from "./components/TabOverview";
 import TabTransactions from "./components/TabTransactions";
+import TabTotalSpending from "./components/TabTotalSpending";
 import { SPLTIconSmall } from "@/components/SPLTIcon";
 import { useParams } from "next/navigation";
 import { useTotalSpend } from "@/api";
@@ -57,14 +58,17 @@ const GroupPage = () => {
         </Group>
         <Stack mb={100}>
           <Center>
-            <TopSummary selectedTab={selectedTab} groupData={groupData} />
+            <TopSummary selectedTab={selectedTab} groupData={groupData} localUserId={localUserId} />
           </Center>
           <Center>
             <Tab selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
           </Center>
-          {selectedTab === TabType.Overview && <TabOverview />}
+          {selectedTab === TabType.Overview && <TabOverview localUserId={localUserId} />}
           {selectedTab === TabType.Transactions && (
-            <TabTransactions groupData={groupData} />
+            <TabTransactions groupData={groupData} localUserId={localUserId} />
+          )}
+          {selectedTab === TabType.TotalSpending && (
+            <TabTotalSpending groupData={groupData} localUserId={localUserId} />
           )}
         </Stack>
         <MadeWithLove />

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Center, Container, Group, Stack } from "@mantine/core";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Tab, { TabType } from "./components/Tab";
 import TopSummary from "./components/TopSummary";
 import TabOverview from "./components/TabOverview";
@@ -9,13 +9,29 @@ import { SPLTIconSmall } from "@/components/SPLTIcon";
 import { useParams } from "next/navigation";
 import { useTotalSpend } from "@/api";
 import MadeWithLove from "@/components/MadeWithLove";
-import ToggleDarkLightMode from "@/components/ToggleDarkLightMode";
 import Metadata from "@/components/Metadata";
+import { useLocalStorage } from "@mantine/hooks";
+import UserSelectionModal from "@/components/UserSelectionModal";
+import UserDropdown from "@/components/UserDropdown";
 
 const GroupPage = () => {
   const { groupId } = useParams<{ groupId: string }>();
   const groupData = useTotalSpend(groupId);
   const [selectedTab, setSelectedTab] = useState(TabType.Transactions);
+
+  const [localUserId, setLocalUserId] = useLocalStorage<string | null>({
+    key: `splt-local-user-${groupId}`,
+    defaultValue: null,
+  });
+
+  const participants = groupData.data?.expand.groupInfo.expand.participants ?? [];
+
+  const currentUser = useMemo(
+    () => participants.find((p) => p.id === localUserId) ?? null,
+    [participants, localUserId]
+  );
+
+  const selectionModalOpen = !groupData.isPending && participants.length > 0 && !localUserId;
 
   return (
     <>
@@ -25,10 +41,19 @@ const GroupPage = () => {
           seoDescription={`${groupData.data?.expand.groupInfo.avatar.emoji} ${groupData.data?.expand.groupInfo.description}`}
         />
       )}
+      <UserSelectionModal
+        opened={!!selectionModalOpen}
+        participants={participants}
+        onSelect={setLocalUserId}
+      />
       <Container size="xs" mt="md">
         <Group justify="space-between">
           <SPLTIconSmall />
-          <ToggleDarkLightMode />
+          <UserDropdown
+            currentUser={currentUser}
+            participants={participants}
+            onSelectUser={setLocalUserId}
+          />
         </Group>
         <Stack mb={100}>
           <Center>

--- a/src/app/group/[groupId]/transaction/components/PaybackPage.tsx
+++ b/src/app/group/[groupId]/transaction/components/PaybackPage.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Center,
   Group, Skeleton,
   Stack,
@@ -9,6 +8,7 @@ import {
   rem
 } from "@mantine/core";
 import { useSearchParams } from "next/navigation";
+import UserAvatar from "@/components/UserAvatar";
 import { useDeletePayback, usePayback } from "@/api";
 import dayjs from "dayjs";
 import { IconArrowNarrowRight } from "@tabler/icons-react";
@@ -66,11 +66,11 @@ const PaybackPage = () => {
           <Group>
             <Stack>
               <Center>
-                <Avatar variant="light" size={rem(80)} radius={rem(80)}>
+                <UserAvatar size={rem(80)} radius={rem(80)}>
                   <Title order={1} style={{ fontSize: rem(50) }}>
                     {data.expand.fromPerson.avatar.emoji}
                   </Title>
-                </Avatar>
+                </UserAvatar>
               </Center>
               <Center>
                 <Title fw={500} order={2} pb="md">
@@ -81,11 +81,11 @@ const PaybackPage = () => {
             <IconArrowNarrowRight size="3rem" stroke={1.5} />
             <Stack>
               <Center>
-                <Avatar variant="light" size={rem(80)} radius={rem(80)}>
+                <UserAvatar size={rem(80)} radius={rem(80)}>
                   <Title order={1} style={{ fontSize: rem(50) }}>
                     {data.expand.toPerson.avatar.emoji}
                   </Title>
-                </Avatar>
+                </UserAvatar>
               </Center>
               <Center>
                 <Title fw={500} order={2} pb="md">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en" {...mantineHtmlProps}>
       <head suppressHydrationWarning>
-        <ColorSchemeScript defaultColorScheme="auto" />
+        <ColorSchemeScript defaultColorScheme="auto" suppressHydrationWarning />
         <link rel="shortcut icon" href="/favicon.svg" />
         <meta
           name="viewport"

--- a/src/components/AddEditTransactionModal/index.tsx
+++ b/src/components/AddEditTransactionModal/index.tsx
@@ -24,6 +24,7 @@ type AddEditTransactionModalProps = {
   button: React.ReactNode;
   isEdit?: boolean;
   expenseData?: ExpenseTransactionData;
+  localUserId?: string | null;
 };
 
 const AddEditTransactionModal = ({
@@ -31,6 +32,7 @@ const AddEditTransactionModal = ({
   button,
   isEdit,
   expenseData,
+  localUserId,
 }: AddEditTransactionModalProps) => {
   const [confirmSuccess, setConfirmSuccess] = useState<boolean>(false);
   const { groupId } = useParams<{ groupId: string }>();
@@ -73,7 +75,7 @@ const AddEditTransactionModal = ({
             name: "",
             avatar: { emoji: randomEmoji(), unified: "" },
             description: "",
-            paidBy: groupData.expand.participants[0].id,
+            paidBy: localUserId ?? groupData.expand.participants[0].id,
             splitType: SplitType.Equal,
             everyoneIsParticipant: true,
             participants: [],

--- a/src/components/AddEditTransactionModal/index.tsx
+++ b/src/components/AddEditTransactionModal/index.tsx
@@ -184,6 +184,7 @@ const AddEditTransactionModal = ({
         }}
         onLastPageHandler={() => {
           form.reset();
+          form.setFieldValue("transactionDateTime", new Date());
         }}
         onCloseModalClick={() => {
           form.reset();

--- a/src/components/ListParticipantsModal/index.tsx
+++ b/src/components/ListParticipantsModal/index.tsx
@@ -9,9 +9,9 @@ import {
   ScrollArea,
   SimpleGrid,
   AvatarGroup,
-  Avatar,
   UnstyledButton,
 } from "@mantine/core";
+import UserAvatar from "@/components/UserAvatar";
 import { useState } from "react";
 import { useDisclosure, useMediaQuery } from "@mantine/hooks";
 import { IconChevronLeft } from "@tabler/icons-react";
@@ -182,9 +182,9 @@ const ListParticipantsModal = ({ groupInfo }: ListParticipantsModalProps) => {
           {groupInfo.expand.participants
             .slice(0, 8)
             .map((participant, index) => (
-              <Avatar key={index}>
+              <UserAvatar key={index}>
                 <Title order={2}>{participant.avatar.emoji}</Title>
-              </Avatar>
+              </UserAvatar>
             ))}
         </AvatarGroup>
       </UnstyledButton>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -99,6 +99,15 @@ const Modal = ({
     }
   }, [confirmSuccess]);
 
+  // Reset carousel and page when modal closes externally (controlled mode),
+  // since Mantine won't fire onClose when opened prop flips to false.
+  useEffect(() => {
+    if (!isOpen) {
+      pageHandler.set(0);
+      embla?.scrollTo(0, true);
+    }
+  }, [isOpen]);
+
   const closeModalHandler = () => {
     setConfirmSuccess?.(false);
     if (isControlled) {
@@ -130,7 +139,7 @@ const Modal = ({
         centered
       >
         <MantineModal.Overlay />
-        <MantineModal.Content radius={isMobile ? 0 : "lg"}>
+        <MantineModal.Content radius={isMobile ? 0 : "lg"} style={isMobile ? { display: "flex", flexDirection: "column", width: "100%" } : undefined}>
           <MantineModal.Header>
             <ActionIcon
               variant="transparent"
@@ -148,14 +157,14 @@ const Modal = ({
             </Text>
             <Space w="xl" h="xl" />
           </MantineModal.Header>
-          <MantineModal.Body>
-            <Stack h={rem(550)} justify="space-between">
+          <MantineModal.Body style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+            <Stack h={isMobile ? undefined : rem(550)} style={isMobile ? { flex: 1 } : undefined} justify="space-between">
               <Carousel
                 emblaOptions={{ watchDrag: false }}
                 withControls={false}
                 getEmblaApi={setEmbla}
                 withKeyboardEvents={false}
-                pb={isMobile ? "xl" : "none"}
+                style={{ flex: 1, minHeight: 0 }}
               >
                 {React.Children.map(children, (child, index) => {
                   const slide = child as React.ReactElement<{ children?: React.ReactNode }>;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -133,13 +133,24 @@ const Modal = ({
           <MantineModal.Body>
             <Stack h={rem(550)} justify="space-between">
               <Carousel
-                draggable={false}
+                emblaOptions={{ watchDrag: false }}
                 withControls={false}
                 getEmblaApi={setEmbla}
                 withKeyboardEvents={false}
                 pb={isMobile ? "xl" : "none"}
               >
-                {children}
+                {React.Children.map(children, (child, index) => {
+                  const slide = child as React.ReactElement<{ children?: React.ReactNode }>;
+                  return React.cloneElement(slide, {
+                    children: (
+                      // inert prevents tab/focus from reaching off-screen slides,
+                      // which would otherwise trigger Embla to scroll to that slide
+                      <div inert={index !== page ? true : undefined}>
+                        {slide.props.children}
+                      </div>
+                    ),
+                  });
+                })}
               </Carousel>
               <ModalFooterButton
                 isMobile={isMobile}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -19,11 +19,9 @@ type ModalPropsType = {
   children: React.ReactNode;
   maxPage: number;
   confirmPage: number;
-  // isActionIcon?: boolean;
   onConfirmClick: () => void;
   onCloseModalClick?: () => void;
-  // buttonTitle?: string;
-  button: React.ReactNode;
+  button?: React.ReactNode;
   page: number;
   pageHandler: any;
   form: UseFormReturnType<any>;
@@ -33,16 +31,21 @@ type ModalPropsType = {
   onLastPageHandler?: () => void;
   keepButtonWhenOpened?: boolean;
   headerTitle?: string;
+  /** Controlled mode: pass opened + onClose to skip the trigger button */
+  opened?: boolean;
+  onClose?: () => void;
+  /** Override the footer per page. Return null to render nothing. */
+  footerContent?: (page: number) => React.ReactNode;
+  /** Ref populated with pageIncrement so slide content can advance pages */
+  pageIncrementRef?: React.RefObject<(() => void) | null>;
 };
 
 const Modal = ({
   maxPage,
   confirmPage,
-  // isActionIcon,
   children,
   onConfirmClick,
   onCloseModalClick,
-  // buttonTitle,
   button,
   page,
   pageHandler,
@@ -53,30 +56,18 @@ const Modal = ({
   onLastPageHandler,
   keepButtonWhenOpened,
   headerTitle,
+  opened: controlledOpened,
+  onClose: controlledOnClose,
+  footerContent,
+  pageIncrementRef,
 }: ModalPropsType) => {
-  useEffect(() => {
-    if (confirmSuccess) {
-      pageIncrement();
-    }
-  }, [confirmSuccess]);
-  // const maxPage = maxPage - 1;
-  const [opened, { open, close }] = useDisclosure(false);
+  const isControlled = controlledOpened !== undefined;
+  const [internalOpened, { open, close }] = useDisclosure(false);
+  const isOpen = isControlled ? controlledOpened! : internalOpened;
+
   const isMobile = useMediaQuery("(max-width: 50em)") || false;
-  // const [page, pageHandler] = useCounter(0, {
-  //   min: 0,
-  //   max: maxPage,
-  // });
   const [embla, setEmbla] = useState<EmblaCarouselType | null>(null);
-  const pageDecrement = () => {
-    scrollPrev();
-    pageHandler.decrement();
-  };
-  const pageIncrement = () => {
-    if (!form.validate().hasErrors) {
-      scrollNext();
-      pageHandler.increment();
-    }
-  };
+
   const scrollPrev = useCallback(() => {
     if (embla) embla.scrollPrev();
   }, [embla]);
@@ -85,15 +76,42 @@ const Modal = ({
     if (embla) embla.scrollNext();
   }, [embla]);
 
+  const pageDecrement = () => {
+    scrollPrev();
+    pageHandler.decrement();
+  };
+
+  const pageIncrement = () => {
+    if (!form.validate().hasErrors) {
+      scrollNext();
+      pageHandler.increment();
+    }
+  };
+
+  // Keep ref current so callers can trigger page advance from slide content
+  useEffect(() => {
+    if (pageIncrementRef) pageIncrementRef.current = pageIncrement;
+  });
+
+  useEffect(() => {
+    if (confirmSuccess) {
+      pageIncrement();
+    }
+  }, [confirmSuccess]);
+
   const closeModalHandler = () => {
-    setConfirmSuccess ? setConfirmSuccess(false) : null;
-    close();
+    setConfirmSuccess?.(false);
+    if (isControlled) {
+      controlledOnClose?.();
+    } else {
+      close();
+    }
     pageHandler.set(0);
   };
 
   const onCloseModal = () => {
     closeModalHandler();
-    onCloseModalClick ? onCloseModalClick() : null;
+    onCloseModalClick?.();
   };
 
   const confirmFunction = () => {
@@ -105,7 +123,7 @@ const Modal = ({
   return (
     <>
       <MantineModal.Root
-        opened={opened}
+        opened={isOpen}
         onClose={onCloseModal}
         fullScreen={isMobile}
         transitionProps={{ transition: "slide-up", duration: 200 }}
@@ -118,7 +136,7 @@ const Modal = ({
               variant="transparent"
               color="gray"
               aria-label="Settings"
-              onClick={page !== 0 ? pageDecrement : close}
+              onClick={page !== 0 ? pageDecrement : (isControlled ? closeModalHandler : close)}
             >
               <IconChevronLeft
                 style={{ width: "70%", height: "70%" }}
@@ -152,23 +170,28 @@ const Modal = ({
                   });
                 })}
               </Carousel>
-              <ModalFooterButton
-                isMobile={isMobile}
-                isModalOpened={opened}
-                page={page}
-                maxPage={maxPage}
-                confirmPage={confirmPage}
-                pageIncrement={pageIncrement}
-                confirmFunction={confirmFunction}
-                closeModalHandler={closeModalHandler}
-                nextButtonIsPending={nextButtonIsPending}
-                onLastPageHandler={onLastPageHandler}
-              />
+              {footerContent !== undefined
+                ? footerContent(page)
+                : (
+                  <ModalFooterButton
+                    isMobile={isMobile}
+                    isModalOpened={isOpen}
+                    page={page}
+                    maxPage={maxPage}
+                    confirmPage={confirmPage}
+                    pageIncrement={pageIncrement}
+                    confirmFunction={confirmFunction}
+                    closeModalHandler={closeModalHandler}
+                    nextButtonIsPending={nextButtonIsPending}
+                    onLastPageHandler={onLastPageHandler}
+                  />
+                )
+              }
             </Stack>
           </MantineModal.Body>
         </MantineModal.Content>
       </MantineModal.Root>
-      {(!opened || keepButtonWhenOpened) && (
+      {!isControlled && (!internalOpened || keepButtonWhenOpened) && (
         <UnstyledButton onClick={open}>{button}</UnstyledButton>
       )}
     </>

--- a/src/components/ParticipantAvatar.tsx
+++ b/src/components/ParticipantAvatar.tsx
@@ -1,6 +1,5 @@
 import { StoreEmojiData } from "@/types";
 import {
-  Avatar,
   Center,
   Container,
   Stack,
@@ -10,6 +9,7 @@ import {
   useComputedColorScheme,
   useMantineTheme,
 } from "@mantine/core";
+import UserAvatar from "@/components/UserAvatar";
 import React from "react";
 
 type ParticipantAvatarProps = {
@@ -49,9 +49,9 @@ const ParticipantAvatar = ({
     >
       <Stack gap="xs">
         <Center>
-          <Avatar size="lg" radius="xl">
+          <UserAvatar size="lg">
             <Title order={1}>{avatar.emoji}</Title>
-          </Avatar>
+          </UserAvatar>
         </Center>
         <Center>
           <Text lineClamp={2} ta="center">

--- a/src/components/ParticipantAvatarHorizontal.tsx
+++ b/src/components/ParticipantAvatarHorizontal.tsx
@@ -1,6 +1,5 @@
 import { StoreEmojiData } from "@/types";
 import {
-  Avatar,
   Container,
   Group,
   Text,
@@ -8,6 +7,7 @@ import {
   useComputedColorScheme,
   useMantineTheme,
 } from "@mantine/core";
+import UserAvatar from "@/components/UserAvatar";
 import React from "react";
 
 type ParticipantAvatarProps = {
@@ -47,9 +47,9 @@ const ParticipantAvatarHorizontal = ({
     >
       <Group justify="space-between" align="center" gap="xs">
         <Group>
-          <Avatar size="md" radius="xl">
+          <UserAvatar size="md">
             <Title order={4}>{avatar.emoji}</Title>
-          </Avatar>
+          </UserAvatar>
           <Text lineClamp={2} ta="center">
             {name}
           </Text>

--- a/src/components/PaymentDetailsModal.tsx
+++ b/src/components/PaymentDetailsModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+import {
+  Button,
+  Center,
+  Input,
+  Modal,
+  rem,
+  SegmentedControl,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { useEffect } from "react";
+import { useCounter } from "@mantine/hooks";
+import { Carousel } from "@mantine/carousel";
+import { Participant, PaymentMethodType } from "@/types";
+import { useUpdateParticipant } from "@/api";
+import ModalComponent from "./Modal";
+import { getHashedSessionId, recordConsent } from "@/lib/consent";
+
+type PaymentDetailsModalProps = {
+  opened: boolean;
+  participant: Participant;
+  onClose: () => void;
+};
+
+const PaymentDetailsModal = ({
+  opened,
+  participant,
+  onClose,
+}: PaymentDetailsModalProps) => {
+  const [page, pageHandler] = useCounter(0, { min: 0, max: 0 });
+  const updateParticipant = useUpdateParticipant();
+
+  const form = useForm<Participant>({
+    initialValues: {
+      avatar: { emoji: "", unified: "" },
+      name: "",
+      accountName: "",
+      selectedPaymentMethod: PaymentMethodType.Iban,
+      paymentMethod: { iban: "", paypal: "" },
+    },
+  });
+
+  useEffect(() => {
+    if (opened) {
+      form.setValues(participant);
+    }
+  }, [opened]);
+
+  const handleSave = async () => {
+    if (!participant.id) return;
+    const needsConsent =
+      form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
+      form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
+    if (needsConsent) {
+      const hashed = await getHashedSessionId();
+      recordConsent(participant.id, hashed);
+    }
+    await updateParticipant.mutateAsync({ ...form.values, id: participant.id });
+    onClose();
+  };
+
+  return (
+    <ModalComponent
+      opened={opened}
+      onClose={onClose}
+      page={page}
+      pageHandler={pageHandler}
+      maxPage={0}
+      confirmPage={-1}
+      onConfirmClick={() => {}}
+      form={form}
+      footerContent={() => {
+        const requiresConsent =
+          form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
+          form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
+        return (
+          <Stack gap="xs" pb="md">
+            {requiresConsent && (
+              <Text size="xs" c="dimmed" ta="center">
+                By saving, you consent to your payment details being stored and visible to group members
+              </Text>
+            )}
+            <Button
+              onClick={handleSave}
+              loading={updateParticipant.isPending}
+              fullWidth
+            >
+              Save
+            </Button>
+          </Stack>
+        );
+      }}
+    >
+      <Carousel.Slide>
+        <Stack gap="md">
+          <Center>
+            <Stack gap={rem(2)} align="center">
+              <Text fw={500}>Payment details</Text>
+              <Text size="sm" c="dimmed">
+                How others pay you back
+              </Text>
+            </Stack>
+          </Center>
+
+          <Stack gap={rem(3)}>
+            <Text size="sm">Preferred Payment By</Text>
+            <SegmentedControl
+              value={form.values.selectedPaymentMethod}
+              onChange={(value) =>
+                form.setFieldValue("selectedPaymentMethod", value as PaymentMethodType)
+              }
+              data={[
+                { label: "IBAN", value: PaymentMethodType.Iban },
+                { label: "Paypal", value: PaymentMethodType.Paypal },
+                { label: "Cash", value: PaymentMethodType.Cash },
+              ]}
+            />
+          </Stack>
+
+          {form.values.selectedPaymentMethod === PaymentMethodType.Iban && (
+            <>
+              <TextInput
+                radius={0}
+                variant="unstyled"
+                size="md"
+                label="Account Name"
+                placeholder="John Doe"
+                {...form.getInputProps("accountName")}
+              />
+              <Input.Wrapper label="IBAN">
+                <Input
+                  radius={0}
+                  variant="unstyled"
+                  size="md"
+                  placeholder="DE00 0000 0000 0000 0000 00"
+                  {...form.getInputProps("paymentMethod.iban")}
+                />
+              </Input.Wrapper>
+            </>
+          )}
+
+          {form.values.selectedPaymentMethod === PaymentMethodType.Paypal && (
+            <TextInput
+              radius={0}
+              variant="unstyled"
+              size="md"
+              label="Paypal Email / Account"
+              placeholder="@johndoe"
+              {...form.getInputProps("paymentMethod.paypal")}
+            />
+          )}
+        </Stack>
+      </Carousel.Slide>
+    </ModalComponent>
+  );
+};
+
+export default PaymentDetailsModal;

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,16 +1,13 @@
 "use client";
-import { Avatar, AvatarProps, useComputedColorScheme } from "@mantine/core";
+import { Avatar, AvatarProps } from "@mantine/core";
 
 const UserAvatar = ({ style, ...props }: AvatarProps) => {
-  const colorScheme = useComputedColorScheme();
   return (
     <Avatar
       variant="transparent"
       style={{
         backgroundColor:
-          colorScheme === "dark"
-            ? "var(--mantine-color-dark-8)"
-            : "var(--mantine-color-gray-4)",
+          "light-dark(var(--mantine-color-gray-4), var(--mantine-color-dark-8))",
         ...style,
       }}
       {...props}

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { Avatar, AvatarProps, useComputedColorScheme } from "@mantine/core";
+
+const UserAvatar = ({ style, ...props }: AvatarProps) => {
+  const colorScheme = useComputedColorScheme();
+  return (
+    <Avatar
+      variant="transparent"
+      style={{
+        backgroundColor:
+          colorScheme === "dark"
+            ? "var(--mantine-color-dark-8)"
+            : "var(--mantine-color-gray-4)",
+        ...style,
+      }}
+      {...props}
+    />
+  );
+};
+
+export default UserAvatar;

--- a/src/components/UserDropdown.tsx
+++ b/src/components/UserDropdown.tsx
@@ -1,0 +1,103 @@
+"use client";
+import {
+  Avatar,
+  Menu,
+  rem,
+  Stack,
+  Text,
+  useComputedColorScheme,
+  useMantineColorScheme,
+} from "@mantine/core";
+import {
+  IconMoonFilled,
+  IconSunFilled,
+  IconUserCircle,
+  IconUsers,
+} from "@tabler/icons-react";
+import { Participant } from "@/types";
+import { useDisclosure } from "@mantine/hooks";
+import UserSelectionModal from "./UserSelectionModal";
+
+type UserDropdownProps = {
+  currentUser: Participant | null;
+  participants: Participant[];
+  onSelectUser: (participantId: string) => void;
+};
+
+const UserDropdown = ({
+  currentUser,
+  participants,
+  onSelectUser,
+}: UserDropdownProps) => {
+  const { setColorScheme } = useMantineColorScheme();
+  const computedColorScheme = useComputedColorScheme();
+  const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure(false);
+
+  const toggleColorScheme = () => {
+    setColorScheme(computedColorScheme === "dark" ? "light" : "dark");
+  };
+
+  const handleSelectUser = (participantId: string) => {
+    onSelectUser(participantId);
+    closeModal();
+  };
+
+  return (
+    <>
+      <UserSelectionModal
+        opened={modalOpened}
+        participants={participants}
+        onSelect={handleSelectUser}
+        onClose={closeModal}
+      />
+      <Menu
+        width={200}
+        position="bottom-end"
+        radius="lg"
+      >
+        <Menu.Target>
+          <Avatar variant="light" radius="xl" size="sm" style={{ cursor: "pointer" }}>
+            {currentUser ? currentUser.avatar.emoji : <IconUserCircle size={16} />}
+          </Avatar>
+        </Menu.Target>
+
+        <Menu.Dropdown>
+          <Menu.Label>
+            <Stack gap={0}>
+              <Text size="xs" c="dimmed" lh={1}>
+                Hello,
+              </Text>
+              <Text size="sm" fw={600} lh={1.4} c="var(--mantine-color-text)">
+                {currentUser ? currentUser.name : "Choose user"}
+              </Text>
+            </Stack>
+          </Menu.Label>
+
+          <Menu.Divider />
+
+          <Menu.Item
+            leftSection={<IconUsers style={{ width: rem(14) }} />}
+            onClick={openModal}
+          >
+            Switch user
+          </Menu.Item>
+
+          <Menu.Item
+            leftSection={
+              computedColorScheme === "dark" ? (
+                <IconSunFilled style={{ width: rem(14) }} />
+              ) : (
+                <IconMoonFilled style={{ width: rem(14) }} />
+              )
+            }
+            onClick={toggleColorScheme}
+          >
+            {computedColorScheme === "dark" ? "Light mode" : "Dark mode"}
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    </>
+  );
+};
+
+export default UserDropdown;

--- a/src/components/UserDropdown.tsx
+++ b/src/components/UserDropdown.tsx
@@ -1,13 +1,14 @@
 "use client";
 import {
-  Avatar,
   Menu,
   rem,
   Stack,
   Text,
+  Title,
   useComputedColorScheme,
   useMantineColorScheme,
 } from "@mantine/core";
+import UserAvatar from "@/components/UserAvatar";
 import {
   IconMoonFilled,
   IconSunFilled,
@@ -56,9 +57,9 @@ const UserDropdown = ({
         radius="lg"
       >
         <Menu.Target>
-          <Avatar variant="light" radius="xl" size="sm" style={{ cursor: "pointer" }}>
-            {currentUser ? currentUser.avatar.emoji : <IconUserCircle size={16} />}
-          </Avatar>
+          <UserAvatar size="md" style={{ cursor: "pointer" }}>
+            {currentUser ? <Title order={3}>{currentUser.avatar.emoji}</Title> : <IconUserCircle size={16} />}
+          </UserAvatar>
         </Menu.Target>
 
         <Menu.Dropdown>

--- a/src/components/UserDropdown.tsx
+++ b/src/components/UserDropdown.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mantine/core";
 import UserAvatar from "@/components/UserAvatar";
 import {
+  IconCreditCard,
   IconMoonFilled,
   IconSunFilled,
   IconUserCircle,
@@ -18,6 +19,7 @@ import {
 import { Participant } from "@/types";
 import { useDisclosure } from "@mantine/hooks";
 import UserSelectionModal from "./UserSelectionModal";
+import PaymentDetailsModal from "./PaymentDetailsModal";
 
 type UserDropdownProps = {
   currentUser: Participant | null;
@@ -33,6 +35,7 @@ const UserDropdown = ({
   const { setColorScheme } = useMantineColorScheme();
   const computedColorScheme = useComputedColorScheme();
   const [modalOpened, { open: openModal, close: closeModal }] = useDisclosure(false);
+  const [paymentModalOpened, { open: openPaymentModal, close: closePaymentModal }] = useDisclosure(false);
 
   const toggleColorScheme = () => {
     setColorScheme(computedColorScheme === "dark" ? "light" : "dark");
@@ -51,6 +54,13 @@ const UserDropdown = ({
         onSelect={handleSelectUser}
         onClose={closeModal}
       />
+      {currentUser && (
+        <PaymentDetailsModal
+          opened={paymentModalOpened}
+          participant={currentUser}
+          onClose={closePaymentModal}
+        />
+      )}
       <Menu
         width={200}
         position="bottom-end"
@@ -81,6 +91,14 @@ const UserDropdown = ({
             onClick={openModal}
           >
             Switch user
+          </Menu.Item>
+
+          <Menu.Item
+            leftSection={<IconCreditCard style={{ width: rem(14) }} />}
+            onClick={openPaymentModal}
+            disabled={!currentUser}
+          >
+            Payment details
           </Menu.Item>
 
           <Menu.Item

--- a/src/components/UserSelectionModal.tsx
+++ b/src/components/UserSelectionModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+import {
+  ActionIcon,
+  Center,
+  Modal,
+  rem,
+  ScrollArea,
+  SimpleGrid,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
+import { Participant } from "@/types";
+import ParticipantAvatar from "./ParticipantAvatar";
+import { useHover, useMediaQuery, useViewportSize } from "@mantine/hooks";
+import { IconX } from "@tabler/icons-react";
+
+type ParticipantItemProps = {
+  participant: Participant;
+  onSelect: (id: string) => void;
+};
+
+const ParticipantItem = ({ participant, onSelect }: ParticipantItemProps) => {
+  const { hovered, ref } = useHover();
+  return (
+    <UnstyledButton ref={ref} onClick={() => participant.id && onSelect(participant.id)}>
+      <ParticipantAvatar
+        avatar={participant.avatar}
+        name={participant.name}
+        isSelected={hovered}
+      />
+    </UnstyledButton>
+  );
+};
+
+type UserSelectionModalProps = {
+  opened: boolean;
+  participants: Participant[];
+  onSelect: (participantId: string) => void;
+  onClose?: () => void;
+};
+
+const UserSelectionModal = ({
+  opened,
+  participants,
+  onSelect,
+  onClose,
+}: UserSelectionModalProps) => {
+  const isMobile = useMediaQuery("(max-width: 50em)") || false;
+  const { height } = useViewportSize();
+  const modalHeight = isMobile ? rem(height - 100) : rem(500);
+
+  return (
+    <Modal.Root
+      opened={opened}
+      onClose={() => onClose?.()}
+      fullScreen={isMobile}
+      transitionProps={{ transition: "pop", duration: 200 }}
+      centered
+    >
+      <Modal.Overlay />
+      <Modal.Content radius={isMobile ? 0 : "lg"}>
+        <Modal.Header>
+          {onClose && (
+            <ActionIcon
+              variant="transparent"
+              color="gray"
+              onClick={onClose}
+              ml="auto"
+            >
+              <IconX style={{ width: "70%", height: "70%" }} stroke={1.5} />
+            </ActionIcon>
+          )}
+        </Modal.Header>
+        <Modal.Body>
+          <ScrollArea h={modalHeight}>
+            <Stack>
+              <Center>
+                <Stack gap={rem(2)} align="center">
+                  <Text fw={500}>Who are you?</Text>
+                  <Text size="sm" c="dimmed">
+                    Choose your name to personalise your experience
+                  </Text>
+                </Stack>
+              </Center>
+              <SimpleGrid cols={3} spacing={0} pb="xl">
+                {participants.map((participant) => (
+                  <ParticipantItem
+                    key={participant.id}
+                    participant={participant}
+                    onSelect={onSelect}
+                  />
+                ))}
+              </SimpleGrid>
+            </Stack>
+          </ScrollArea>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+};
+
+export default UserSelectionModal;

--- a/src/components/UserSelectionModal.tsx
+++ b/src/components/UserSelectionModal.tsx
@@ -20,6 +20,7 @@ import ParticipantAvatar from "./ParticipantAvatar";
 import { useHover } from "@mantine/hooks";
 import { useUpdateParticipant } from "@/api";
 import Modal from "./Modal";
+import { getHashedSessionId, recordConsent } from "@/lib/consent";
 
 type ParticipantItemProps = {
   participant: Participant;
@@ -98,6 +99,13 @@ const UserSelectionModal = ({
 
   const handleSave = async () => {
     if (!selectedParticipant?.id) return;
+    const needsConsent =
+      form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
+      form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
+    if (needsConsent) {
+      const hashed = await getHashedSessionId();
+      recordConsent(selectedParticipant.id, hashed);
+    }
     await updateParticipant.mutateAsync({
       ...form.values,
       id: selectedParticipant.id,
@@ -122,8 +130,16 @@ const UserSelectionModal = ({
       pageIncrementRef={pageIncrementRef}
       footerContent={(currentPage) => {
         if (currentPage === 0) return null;
+        const requiresConsent =
+          form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
+          form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
         return (
           <Stack gap="xs" pb="md">
+            {requiresConsent && (
+              <Text size="xs" c="dimmed" ta="center">
+                By saving, you consent to your payment details being stored and visible to group members
+              </Text>
+            )}
             <Button
               onClick={handleSave}
               loading={updateParticipant.isPending}

--- a/src/components/UserSelectionModal.tsx
+++ b/src/components/UserSelectionModal.tsx
@@ -1,19 +1,25 @@
 "use client";
 import {
-  ActionIcon,
+  Button,
   Center,
-  Modal,
+  Input,
   rem,
-  ScrollArea,
+  SegmentedControl,
   SimpleGrid,
   Stack,
   Text,
+  TextInput,
   UnstyledButton,
 } from "@mantine/core";
-import { Participant } from "@/types";
+import { useForm } from "@mantine/form";
+import { useRef, useState } from "react";
+import { useCounter } from "@mantine/hooks";
+import { Carousel } from "@mantine/carousel";
+import { Participant, PaymentMethodType } from "@/types";
 import ParticipantAvatar from "./ParticipantAvatar";
-import { useHover, useMediaQuery, useViewportSize } from "@mantine/hooks";
-import { IconX } from "@tabler/icons-react";
+import { useHover } from "@mantine/hooks";
+import { useUpdateParticipant } from "@/api";
+import Modal from "./Modal";
 
 type ParticipantItemProps = {
   participant: Participant;
@@ -23,7 +29,10 @@ type ParticipantItemProps = {
 const ParticipantItem = ({ participant, onSelect }: ParticipantItemProps) => {
   const { hovered, ref } = useHover();
   return (
-    <UnstyledButton ref={ref} onClick={() => participant.id && onSelect(participant.id)}>
+    <UnstyledButton
+      ref={ref}
+      onClick={() => participant.id && onSelect(participant.id)}
+    >
       <ParticipantAvatar
         avatar={participant.avatar}
         name={participant.name}
@@ -46,57 +55,184 @@ const UserSelectionModal = ({
   onSelect,
   onClose,
 }: UserSelectionModalProps) => {
-  const isMobile = useMediaQuery("(max-width: 50em)") || false;
-  const { height } = useViewportSize();
-  const modalHeight = isMobile ? rem(height - 100) : rem(500);
+  const [page, pageHandler] = useCounter(0, { min: 0, max: 1 });
+  const pageIncrementRef = useRef<(() => void) | null>(null);
+  const [selectedParticipant, setSelectedParticipant] =
+    useState<Participant | null>(null);
+  const updateParticipant = useUpdateParticipant();
+
+  const form = useForm<Participant>({
+    initialValues: {
+      avatar: { emoji: "", unified: "" },
+      name: "",
+      accountName: "",
+      selectedPaymentMethod: PaymentMethodType.Iban,
+      paymentMethod: { iban: "", paypal: "" },
+    },
+  });
+
+  const hasPaymentDetails = (p: Participant): boolean => {
+    switch (p.selectedPaymentMethod) {
+      case PaymentMethodType.Cash:
+        return true;
+      case PaymentMethodType.Iban:
+        return p.paymentMethod.iban.trim().length > 0;
+      case PaymentMethodType.Paypal:
+        return p.paymentMethod.paypal.trim().length > 0;
+      default:
+        return false;
+    }
+  };
+
+  const handleParticipantSelect = (participantId: string) => {
+    const participant = participants.find((p) => p.id === participantId);
+    if (!participant) return;
+    if (hasPaymentDetails(participant)) {
+      onSelect(participantId);
+      return;
+    }
+    setSelectedParticipant(participant);
+    form.setValues(participant);
+    pageIncrementRef.current?.();
+  };
+
+  const handleSave = async () => {
+    if (!selectedParticipant?.id) return;
+    await updateParticipant.mutateAsync({
+      ...form.values,
+      id: selectedParticipant.id,
+    });
+    onSelect(selectedParticipant.id);
+  };
+
+  const handleSkip = () => {
+    if (selectedParticipant?.id) onSelect(selectedParticipant.id);
+  };
 
   return (
-    <Modal.Root
+    <Modal
       opened={opened}
-      onClose={() => onClose?.()}
-      fullScreen={isMobile}
-      transitionProps={{ transition: "pop", duration: 200 }}
-      centered
-    >
-      <Modal.Overlay />
-      <Modal.Content radius={isMobile ? 0 : "lg"}>
-        <Modal.Header>
-          {onClose && (
-            <ActionIcon
-              variant="transparent"
-              color="gray"
-              onClick={onClose}
-              ml="auto"
+      onClose={onClose}
+      page={page}
+      pageHandler={pageHandler}
+      maxPage={1}
+      confirmPage={-1}
+      onConfirmClick={() => {}}
+      form={form}
+      pageIncrementRef={pageIncrementRef}
+      footerContent={(currentPage) => {
+        if (currentPage === 0) return null;
+        return (
+          <Stack gap="xs" pb="md">
+            <Button
+              onClick={handleSave}
+              loading={updateParticipant.isPending}
+              fullWidth
             >
-              <IconX style={{ width: "70%", height: "70%" }} stroke={1.5} />
-            </ActionIcon>
-          )}
-        </Modal.Header>
-        <Modal.Body>
-          <ScrollArea h={modalHeight}>
-            <Stack>
-              <Center>
-                <Stack gap={rem(2)} align="center">
-                  <Text fw={500}>Who are you?</Text>
-                  <Text size="sm" c="dimmed">
-                    Choose your name to personalise your experience
-                  </Text>
-                </Stack>
-              </Center>
-              <SimpleGrid cols={3} spacing={0} pb="xl">
-                {participants.map((participant) => (
-                  <ParticipantItem
-                    key={participant.id}
-                    participant={participant}
-                    onSelect={onSelect}
-                  />
-                ))}
-              </SimpleGrid>
+              Save
+            </Button>
+            <Center>
+              <Text
+                size="sm"
+                c="dimmed"
+                style={{ cursor: "pointer", textDecoration: "underline" }}
+                onClick={handleSkip}
+              >
+                Skip for now
+              </Text>
+            </Center>
+          </Stack>
+        );
+      }}
+    >
+      {/* Step 1: Who are you? */}
+      <Carousel.Slide>
+        <Stack>
+          <Center>
+            <Stack gap={rem(2)} align="center">
+              <Text fw={500}>Who are you?</Text>
+              <Text size="sm" c="dimmed">
+                Choose your name to personalise your experience
+              </Text>
             </Stack>
-          </ScrollArea>
-        </Modal.Body>
-      </Modal.Content>
-    </Modal.Root>
+          </Center>
+          <SimpleGrid cols={3} spacing={0} pb="xl">
+            {participants.map((participant) => (
+              <ParticipantItem
+                key={participant.id}
+                participant={participant}
+                onSelect={handleParticipantSelect}
+              />
+            ))}
+          </SimpleGrid>
+        </Stack>
+      </Carousel.Slide>
+
+      {/* Step 2: Payment details */}
+      <Carousel.Slide>
+        <Stack gap="md">
+          <Center>
+            <Stack gap={rem(2)} align="center" pb="lg">
+              <Text fw={500}>Your payment details</Text>
+              <Text size="sm" c="dimmed">
+                So others know how to pay you back
+              </Text>
+            </Stack>
+          </Center>
+
+          <Stack gap={rem(3)}>
+            <Text size="sm">Preferred Payment By</Text>
+            <SegmentedControl
+              value={form.values.selectedPaymentMethod}
+              onChange={(value) =>
+                form.setFieldValue(
+                  "selectedPaymentMethod",
+                  value as PaymentMethodType,
+                )
+              }
+              data={[
+                { label: "IBAN", value: PaymentMethodType.Iban },
+                { label: "Paypal", value: PaymentMethodType.Paypal },
+                { label: "Cash", value: PaymentMethodType.Cash },
+              ]}
+            />
+          </Stack>
+
+          {form.values.selectedPaymentMethod === PaymentMethodType.Iban && (
+            <>
+              <TextInput
+                radius={0}
+                variant="unstyled"
+                size="md"
+                label="Account Name"
+                placeholder="John Doe"
+                {...form.getInputProps("accountName")}
+              />
+              <Input.Wrapper label="IBAN">
+                <Input
+                  radius={0}
+                  variant="unstyled"
+                  size="md"
+                  placeholder="DE00 0000 0000 0000 0000 00"
+                  {...form.getInputProps("paymentMethod.iban")}
+                />
+              </Input.Wrapper>
+            </>
+          )}
+
+          {form.values.selectedPaymentMethod === PaymentMethodType.Paypal && (
+            <TextInput
+              radius={0}
+              variant="unstyled"
+              size="md"
+              label="Paypal Email / Account"
+              placeholder="@johndoe"
+              {...form.getInputProps("paymentMethod.paypal")}
+            />
+          )}
+        </Stack>
+      </Carousel.Slide>
+    </Modal>
   );
 };
 

--- a/src/components/ViewDebtModal/index.tsx
+++ b/src/components/ViewDebtModal/index.tsx
@@ -8,7 +8,6 @@ import {
   Text,
   ScrollArea,
   AvatarGroup,
-  Avatar,
   UnstyledButton,
   NavLink,
   Group,
@@ -16,6 +15,7 @@ import {
   Container,
 } from "@mantine/core";
 import { useDisclosure, useMediaQuery } from "@mantine/hooks";
+import UserAvatar from "@/components/UserAvatar";
 import { IconChevronLeft } from "@tabler/icons-react";
 import { DebtData, PaybackFormValues, PaymentMethodType } from "@/types";
 import { useParams, useRouter } from "next/navigation";
@@ -105,15 +105,14 @@ const ViewDebtModal = ({ debt }: ViewDebtModalProps) => {
                       <Group>
                         <Stack>
                           <Center>
-                            <Avatar
-                              variant="default"
+                            <UserAvatar
                               size={rem(80)}
                               radius={rem(80)}
                             >
                               <Title order={1} style={{ fontSize: rem(50) }}>
                                 {debt.fromPerson.avatar.emoji}
                               </Title>
-                            </Avatar>
+                            </UserAvatar>
                           </Center>
                           <Center>
                             <Title fw={500} order={2} pb="md">
@@ -131,15 +130,14 @@ const ViewDebtModal = ({ debt }: ViewDebtModalProps) => {
                         </Stack>
                         <Stack>
                           <Center>
-                            <Avatar
-                              variant="default"
+                            <UserAvatar
                               size={rem(80)}
                               radius={rem(80)}
                             >
                               <Title order={1} style={{ fontSize: rem(50) }}>
                                 {debt.toPerson.avatar.emoji}
                               </Title>
-                            </Avatar>
+                            </UserAvatar>
                           </Center>
                           <Center>
                             <Title fw={500} order={2} pb="md">
@@ -291,12 +289,12 @@ const ViewDebtModal = ({ debt }: ViewDebtModalProps) => {
           label={`${debt.fromPerson.name} → ${debt.toPerson.name}`}
           leftSection={
             <AvatarGroup>
-              <Avatar>
+              <UserAvatar>
                 <Title order={2}>{debt.fromPerson.avatar.emoji}</Title>
-              </Avatar>
-              <Avatar>
+              </UserAvatar>
+              <UserAvatar>
                 <Title order={2}>{debt.toPerson.avatar.emoji}</Title>
-              </Avatar>
+              </UserAvatar>
             </AvatarGroup>
           }
           rightSection={

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,45 @@
+const SESSION_KEY = "splt-session-id";
+const CONSENTS_KEY = "splt-consents";
+
+type ConsentRecord = {
+  participantId: string;
+  hashedSessionId: string;
+  consentGivenAt: string;
+};
+
+function getOrCreateSessionId(): string {
+  let sessionId = localStorage.getItem(SESSION_KEY);
+  if (!sessionId) {
+    sessionId = crypto.randomUUID();
+    localStorage.setItem(SESSION_KEY, sessionId);
+  }
+  return sessionId;
+}
+
+export async function getHashedSessionId(): Promise<string> {
+  const sessionId = getOrCreateSessionId();
+  const encoded = new TextEncoder().encode(sessionId);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function recordConsent(participantId: string, hashedSessionId: string): void {
+  const raw = localStorage.getItem(CONSENTS_KEY);
+  const consents: ConsentRecord[] = raw ? JSON.parse(raw) : [];
+
+  const existing = consents.findIndex((c) => c.participantId === participantId);
+  const record: ConsentRecord = {
+    participantId,
+    hashedSessionId,
+    consentGivenAt: new Date().toISOString(),
+  };
+
+  if (existing >= 0) {
+    consents[existing] = record;
+  } else {
+    consents.push(record);
+  }
+
+  localStorage.setItem(CONSENTS_KEY, JSON.stringify(consents));
+}


### PR DESCRIPTION
## Summary

- Add user selection modal and dropdown for group page — lets local user pick which member they are
- Add Total Spending tab showing per-user spending breakdown with UserAvatar
- Add PaymentDetailsModal and consent handling (`src/lib/consent.ts`) for payment info collection
- Multi-step UserSelectionModal flow: pick user → optionally enter payment details
- Refactor `Modal.tsx` for swipeable/z-index fixes; refactor Tab, TopSummary components to support local user context

## Test plan

- [x] Open group page → user selection dropdown appears
- [x] Select user → persists in local state, reflects in TopSummary
- [x] Total Spending tab renders correct per-user data
- [x] UserSelectionModal multi-step: user pick → payment details step → consent saved
- [x] PaymentDetailsModal opens/closes correctly, consent flag stored
- [x] Add transaction → date correct (regression: wrong date fix)
- [x] Modal swipe/z-index behaves on mobile viewport

🤖 Generated with [Claude Code](https://claude.ai/claude-code)