### PR TITLE
feat: IBAN validation, formatting, and PaymentForm component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dayjs": "^1.11.19",
         "embla-carousel-react": "^8.6.0",
         "emoji-picker-react": "^4.16.1",
+        "ibantools": "^4.5.4",
         "next": "16.1.1",
         "pocketbase": "^0.26.5",
         "react": "19.2.3",
@@ -5528,6 +5529,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/ibantools": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/ibantools/-/ibantools-4.5.4.tgz",
+      "integrity": "sha512-6jX1gh4aH6XH+o0ey+wtkMTzkcvsEta7DakIOZSng9voZYpMw3U+gK1+tZChk3aRcPcloEt0NOzksjaRZiqXbw==",
+      "license": "MIT or MPL-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dayjs": "^1.11.19",
     "embla-carousel-react": "^8.6.0",
     "emoji-picker-react": "^4.16.1",
+    "ibantools": "^4.5.4",
     "next": "16.1.1",
     "pocketbase": "^0.26.5",
     "react": "19.2.3",

--- a/src/app/group/[groupId]/components/TabTotalSpending.tsx
+++ b/src/app/group/[groupId]/components/TabTotalSpending.tsx
@@ -36,7 +36,10 @@ type SelectedPerson = {
 
 const MAX_AVATARS = 5;
 
-const TabTotalSpending = ({ groupData, localUserId }: TabTotalSpendingProps) => {
+const TabTotalSpending = ({
+  groupData,
+  localUserId,
+}: TabTotalSpendingProps) => {
   const { groupId } = useParams<{ groupId: string }>();
   const { data, isPending } = useTransactions(groupId);
   const [opened, { open, close }] = useDisclosure(false);
@@ -101,53 +104,68 @@ const TabTotalSpending = ({ groupData, localUserId }: TabTotalSpendingProps) => 
           <Modal.Content radius={isMobile ? 0 : "lg"}>
             <Modal.Header>
               <ActionIcon variant="transparent" color="gray" onClick={close}>
-                <IconChevronLeft style={{ width: "70%", height: "70%" }} stroke={1.5} />
+                <IconChevronLeft
+                  style={{ width: "70%", height: "70%" }}
+                  stroke={1.5}
+                />
               </ActionIcon>
             </Modal.Header>
             <Modal.Body>
               {selected && (
                 <ScrollArea h={modalHeight}>
-                <Stack>
-                  <Center>
-                    <Stack gap={rem(4)} align="center">
-                      <UserAvatar size="lg">
-                        <Title order={2}>{selected.participant.avatar.emoji}</Title>
-                      </UserAvatar>
-                      <Text fw={600}>{selected.participant.name}</Text>
-                      <Text size="sm" c="dimmed">
-                        <EuroNumberFormatter value={selected.total} /> paid
-                      </Text>
+                  <Stack>
+                    <Center>
+                      <Stack gap={rem(4)} align="center">
+                        <UserAvatar size="lg">
+                          <Title order={2}>
+                            {selected.participant.avatar.emoji}
+                          </Title>
+                        </UserAvatar>
+                        <Text size="xl" fw={600}>
+                          {selected.participant.name}
+                        </Text>
+                        <Text size="sm" c="dimmed">
+                          <EuroNumberFormatter value={selected.total} /> paid
+                        </Text>
+                      </Stack>
+                    </Center>
+                    <Stack gap="xs" mt="sm">
+                      {selected.expenses.length === 0 ? (
+                        <Center p="lg">
+                          <Text c="dimmed" size="sm">
+                            No transaction
+                          </Text>
+                        </Center>
+                      ) : (
+                        selected.expenses
+                          .sort(
+                            (a, b) =>
+                              Date.parse(b.transactionDateTime) -
+                              Date.parse(a.transactionDateTime),
+                          )
+                          .map((e) => (
+                            <NavLink
+                              key={e.id}
+                              label={e.name}
+                              description={DateToCalendar({
+                                date: e.transactionDateTime,
+                              })}
+                              leftSection={
+                                <Avatar size="sm" radius="xl">
+                                  {e.avatar.emoji}
+                                </Avatar>
+                              }
+                              rightSection={
+                                <Text fw={500} size="sm">
+                                  <EuroNumberFormatter value={e.amount} />
+                                </Text>
+                              }
+                              style={{ pointerEvents: "none" }}
+                            />
+                          ))
+                      )}
                     </Stack>
-                  </Center>
-                  <Stack gap="xs" mt="sm">
-                    {selected.expenses.length === 0 ? (
-                      <Center p="lg">
-                        <Text c="dimmed" size="sm">No transaction</Text>
-                      </Center>
-                    ) : (
-                      selected.expenses
-                        .sort((a, b) => Date.parse(b.transactionDateTime) - Date.parse(a.transactionDateTime))
-                        .map((e) => (
-                          <NavLink
-                            key={e.id}
-                            label={e.name}
-                            description={DateToCalendar({ date: e.transactionDateTime })}
-                            leftSection={
-                              <Avatar size="sm" radius="xl">
-                                {e.avatar.emoji}
-                              </Avatar>
-                            }
-                            rightSection={
-                              <Text fw={500} size="sm">
-                                <EuroNumberFormatter value={e.amount} />
-                              </Text>
-                            }
-                            style={{ pointerEvents: "none" }}
-                          />
-                        ))
-                    )}
                   </Stack>
-                </Stack>
                 </ScrollArea>
               )}
             </Modal.Body>

--- a/src/components/AddParticipantModal/components/PageSetPayment.tsx
+++ b/src/components/AddParticipantModal/components/PageSetPayment.tsx
@@ -1,17 +1,9 @@
 import EmojiActionButtion from "@/components/EmojiActionButtion";
-import {
-  Center,
-  Container,
-  Input,
-  SegmentedControl,
-  Stack,
-  Text,
-  TextInput,
-  rem,
-} from "@mantine/core";
+import { Center, Container, Stack } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
-import { Participant, PaymentMethodType } from "@/types";
+import { Participant } from "@/types";
 import BigTextInput from "@/components/BigTextInput";
+import PaymentForm from "@/components/PaymentForm";
 
 type PageSetPaymentProps = {
   disabledPreferredPaymentMethod?: boolean;
@@ -36,70 +28,10 @@ const PageSetPayment = ({
             {...form.getInputProps("name")}
           />
         </Center>
-        {!disabledPreferredPaymentMethod && (
-          <>
-            <Stack gap={rem(3)} mb="xs">
-              <Text>Preferred Payment By</Text>
-              <SegmentedControl
-                value={form.values.selectedPaymentMethod}
-                onChange={(value) => {
-                  form.setFieldValue(
-                    "selectedPaymentMethod",
-                    value as PaymentMethodType
-                  );
-                }}
-                data={[
-                  { label: "IBAN", value: PaymentMethodType.Iban },
-                  {
-                    label: "Paypal",
-                    value: PaymentMethodType.Paypal,
-                  },
-                  { label: "Cash", value: PaymentMethodType.Cash },
-                ]}
-              />
-            </Stack>
-            {form.values.selectedPaymentMethod === PaymentMethodType.Iban && (
-              <>
-                <TextInput
-                  radius={0}
-                  variant="unstyled"
-                  size="md"
-                  label="Account Name"
-                  placeholder="John Doe"
-                  {...form.getInputProps("accountName")}
-                />
-                <Input.Wrapper label="IBAN">
-                  <Input
-                    radius={0}
-                    variant="unstyled"
-                    size="md"
-                    placeholder="DE00 0000 0000 0000 0000 00"
-                    // TODO: Fix masking doesn't work with autofill
-                    // component={IMaskInput}
-                    // mask="aa00 0000 0000 0000 0000 00"
-                    // value={form.values.paymentMethod.iban}
-                    // onChange={(event) => {
-                    //   form.setFieldValue("paymentMethod.iban", event);
-                    // }}
-                    {...form.getInputProps("paymentMethod.iban")}
-                  />
-                </Input.Wrapper>
-              </>
-            )}
-            {form.values.selectedPaymentMethod === PaymentMethodType.Paypal && (
-              <>
-                <TextInput
-                  radius={0}
-                  variant="unstyled"
-                  size="md"
-                  label="Paypal Email / Account"
-                  placeholder="@johndoe"
-                  {...form.getInputProps("paymentMethod.paypal")}
-                />
-              </>
-            )}
-          </>
-        )}
+        <PaymentForm
+          form={form}
+          disabledPreferredPaymentMethod={disabledPreferredPaymentMethod}
+        />
       </Stack>
     </Container>
   );

--- a/src/components/AddParticipantModal/index.tsx
+++ b/src/components/AddParticipantModal/index.tsx
@@ -77,6 +77,7 @@ const AddParticipantModal = ({
               ? "Person name must include at least 1 character"
               : null,
           "paymentMethod.iban":
+            !disabledPreferredPaymentMethod &&
             values.selectedPaymentMethod === PaymentMethodType.Iban
               ? validateIban(values.paymentMethod.iban)
               : null,

--- a/src/components/AddParticipantModal/index.tsx
+++ b/src/components/AddParticipantModal/index.tsx
@@ -10,6 +10,7 @@ import { Participant, PaymentMethodType } from "@/types";
 import PageSetPayment from "./components/PageSetPayment";
 import { randomPersonEmoji } from "@/utils/randomEmoji";
 import PageNotifyFinish from "./components/PageNotifyFinish";
+import { validateIban } from "@/lib/validateIban";
 // import { useId } from "@mantine/hooks";
 
 const NewParticipantAvatar = () => {
@@ -74,6 +75,10 @@ const AddParticipantModal = ({
           name:
             values.name.trim().length < 1
               ? "Person name must include at least 1 character"
+              : null,
+          "paymentMethod.iban":
+            values.selectedPaymentMethod === PaymentMethodType.Iban
+              ? validateIban(values.paymentMethod.iban)
               : null,
         };
       }

--- a/src/components/IbanInput.tsx
+++ b/src/components/IbanInput.tsx
@@ -1,0 +1,35 @@
+import { Input } from "@mantine/core";
+import React from "react";
+
+type IbanInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  error?: React.ReactNode;
+};
+
+const formatIban = (raw: string) =>
+  raw
+    .replace(/\s/g, "")
+    .toUpperCase()
+    .replace(/(.{4})/g, "$1 ")
+    .trim();
+
+const IbanInput = ({ value, onChange, error }: IbanInputProps) => (
+  <Input.Wrapper label="IBAN" error={error}>
+    <Input
+      radius={0}
+      variant="unstyled"
+      size="md"
+      placeholder="DE00 0000 0000 0000 0000 00"
+      value={formatIban(value)}
+      onChange={(e) =>
+        onChange(e.currentTarget.value.replace(/\s/g, "").toUpperCase().slice(0, 34))
+      }
+      onKeyDown={(e) => {
+        if (e.key === " ") e.preventDefault();
+      }}
+    />
+  </Input.Wrapper>
+);
+
+export default IbanInput;

--- a/src/components/PaymentDetailsModal.tsx
+++ b/src/components/PaymentDetailsModal.tsx
@@ -18,6 +18,7 @@ import { Participant, PaymentMethodType } from "@/types";
 import { useUpdateParticipant } from "@/api";
 import ModalComponent from "./Modal";
 import { getHashedSessionId, recordConsent } from "@/lib/consent";
+import { validateIban } from "@/lib/validateIban";
 
 type PaymentDetailsModalProps = {
   opened: boolean;
@@ -41,6 +42,12 @@ const PaymentDetailsModal = ({
       selectedPaymentMethod: PaymentMethodType.Iban,
       paymentMethod: { iban: "", paypal: "" },
     },
+    validate: (values) => ({
+      "paymentMethod.iban":
+        values.selectedPaymentMethod === PaymentMethodType.Iban
+          ? validateIban(values.paymentMethod.iban)
+          : null,
+    }),
   });
 
   useEffect(() => {
@@ -51,6 +58,7 @@ const PaymentDetailsModal = ({
 
   const handleSave = async () => {
     if (!participant.id) return;
+    if (form.validate().hasErrors) return;
     const needsConsent =
       form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
       form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
@@ -130,7 +138,10 @@ const PaymentDetailsModal = ({
                 placeholder="John Doe"
                 {...form.getInputProps("accountName")}
               />
-              <Input.Wrapper label="IBAN">
+              <Input.Wrapper
+                label="IBAN"
+                error={form.errors["paymentMethod.iban"]}
+              >
                 <Input
                   radius={0}
                   variant="unstyled"

--- a/src/components/PaymentDetailsModal.tsx
+++ b/src/components/PaymentDetailsModal.tsx
@@ -1,17 +1,8 @@
 "use client";
-import {
-  Button,
-  Center,
-  Input,
-  Modal,
-  rem,
-  SegmentedControl,
-  Stack,
-  Text,
-  TextInput,
-} from "@mantine/core";
+import { Button, Center, rem, Stack, Text } from "@mantine/core";
+import PaymentForm from "@/components/PaymentForm";
 import { useForm } from "@mantine/form";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useCounter } from "@mantine/hooks";
 import { Carousel } from "@mantine/carousel";
 import { Participant, PaymentMethodType } from "@/types";
@@ -70,6 +61,35 @@ const PaymentDetailsModal = ({
     onClose();
   };
 
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = handleSave;
+
+  const requiresConsent =
+    form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
+    form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
+
+  const footerContent = useCallback(
+    () => (
+      <Stack gap="xs" pb="md">
+        {requiresConsent && (
+          <Text size="xs" c="dimmed" ta="center">
+            By saving, you consent to your payment details being stored and visible to group members
+          </Text>
+        )}
+        <Button
+          onClick={() => handleSaveRef.current()}
+          loading={updateParticipant.isPending}
+          fullWidth
+          radius="xl"
+          loaderProps={{ type: "dots" }}
+        >
+          Save
+        </Button>
+      </Stack>
+    ),
+    [requiresConsent, updateParticipant.isPending]
+  );
+
   return (
     <ModalComponent
       opened={opened}
@@ -80,27 +100,7 @@ const PaymentDetailsModal = ({
       confirmPage={-1}
       onConfirmClick={() => {}}
       form={form}
-      footerContent={() => {
-        const requiresConsent =
-          form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
-          form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
-        return (
-          <Stack gap="xs" pb="md">
-            {requiresConsent && (
-              <Text size="xs" c="dimmed" ta="center">
-                By saving, you consent to your payment details being stored and visible to group members
-              </Text>
-            )}
-            <Button
-              onClick={handleSave}
-              loading={updateParticipant.isPending}
-              fullWidth
-            >
-              Save
-            </Button>
-          </Stack>
-        );
-      }}
+      footerContent={footerContent}
     >
       <Carousel.Slide>
         <Stack gap="md">
@@ -113,56 +113,7 @@ const PaymentDetailsModal = ({
             </Stack>
           </Center>
 
-          <Stack gap={rem(3)}>
-            <Text size="sm">Preferred Payment By</Text>
-            <SegmentedControl
-              value={form.values.selectedPaymentMethod}
-              onChange={(value) =>
-                form.setFieldValue("selectedPaymentMethod", value as PaymentMethodType)
-              }
-              data={[
-                { label: "IBAN", value: PaymentMethodType.Iban },
-                { label: "Paypal", value: PaymentMethodType.Paypal },
-                { label: "Cash", value: PaymentMethodType.Cash },
-              ]}
-            />
-          </Stack>
-
-          {form.values.selectedPaymentMethod === PaymentMethodType.Iban && (
-            <>
-              <TextInput
-                radius={0}
-                variant="unstyled"
-                size="md"
-                label="Account Name"
-                placeholder="John Doe"
-                {...form.getInputProps("accountName")}
-              />
-              <Input.Wrapper
-                label="IBAN"
-                error={form.errors["paymentMethod.iban"]}
-              >
-                <Input
-                  radius={0}
-                  variant="unstyled"
-                  size="md"
-                  placeholder="DE00 0000 0000 0000 0000 00"
-                  {...form.getInputProps("paymentMethod.iban")}
-                />
-              </Input.Wrapper>
-            </>
-          )}
-
-          {form.values.selectedPaymentMethod === PaymentMethodType.Paypal && (
-            <TextInput
-              radius={0}
-              variant="unstyled"
-              size="md"
-              label="Paypal Email / Account"
-              placeholder="@johndoe"
-              {...form.getInputProps("paymentMethod.paypal")}
-            />
-          )}
+          <PaymentForm form={form} />
         </Stack>
       </Carousel.Slide>
     </ModalComponent>

--- a/src/components/PaymentForm.tsx
+++ b/src/components/PaymentForm.tsx
@@ -1,0 +1,63 @@
+import { SegmentedControl, Stack, Text, TextInput, rem } from "@mantine/core";
+import { UseFormReturnType } from "@mantine/form";
+import { Participant, PaymentMethodType } from "@/types";
+import IbanInput from "@/components/IbanInput";
+
+type PaymentFormProps = {
+  form: UseFormReturnType<Participant>;
+  disabledPreferredPaymentMethod?: boolean;
+};
+
+const PaymentForm = ({ form, disabledPreferredPaymentMethod }: PaymentFormProps) => {
+  if (disabledPreferredPaymentMethod) return null;
+
+  return (
+    <Stack gap="xs">
+      <Stack gap={rem(3)}>
+        <Text size="sm">Preferred Payment By</Text>
+        <SegmentedControl
+          value={form.values.selectedPaymentMethod}
+          onChange={(value) =>
+            form.setFieldValue("selectedPaymentMethod", value as PaymentMethodType)
+          }
+          data={[
+            { label: "IBAN", value: PaymentMethodType.Iban },
+            { label: "Paypal", value: PaymentMethodType.Paypal },
+            { label: "Cash", value: PaymentMethodType.Cash },
+          ]}
+        />
+      </Stack>
+
+      {form.values.selectedPaymentMethod === PaymentMethodType.Iban && (
+        <>
+          <TextInput
+            radius={0}
+            variant="unstyled"
+            size="md"
+            label="Account Name"
+            placeholder="John Doe"
+            {...form.getInputProps("accountName")}
+          />
+          <IbanInput
+            value={form.values.paymentMethod.iban}
+            onChange={(v) => form.setFieldValue("paymentMethod.iban", v)}
+            error={form.errors["paymentMethod.iban"]}
+          />
+        </>
+      )}
+
+      {form.values.selectedPaymentMethod === PaymentMethodType.Paypal && (
+        <TextInput
+          radius={0}
+          variant="unstyled"
+          size="md"
+          label="Paypal Email / Account"
+          placeholder="@johndoe"
+          {...form.getInputProps("paymentMethod.paypal")}
+        />
+      )}
+    </Stack>
+  );
+};
+
+export default PaymentForm;

--- a/src/components/UserSelectionModal.tsx
+++ b/src/components/UserSelectionModal.tsx
@@ -2,13 +2,10 @@
 import {
   Button,
   Center,
-  Input,
   rem,
-  SegmentedControl,
   SimpleGrid,
   Stack,
   Text,
-  TextInput,
   UnstyledButton,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
@@ -22,6 +19,7 @@ import { useUpdateParticipant } from "@/api";
 import Modal from "./Modal";
 import { getHashedSessionId, recordConsent } from "@/lib/consent";
 import { validateIban } from "@/lib/validateIban";
+import PaymentForm from "@/components/PaymentForm";
 
 type ParticipantItemProps = {
   participant: Participant;
@@ -204,56 +202,7 @@ const UserSelectionModal = ({
             </Stack>
           </Center>
 
-          <Stack gap={rem(3)}>
-            <Text size="sm">Preferred Payment By</Text>
-            <SegmentedControl
-              value={form.values.selectedPaymentMethod}
-              onChange={(value) =>
-                form.setFieldValue(
-                  "selectedPaymentMethod",
-                  value as PaymentMethodType,
-                )
-              }
-              data={[
-                { label: "IBAN", value: PaymentMethodType.Iban },
-                { label: "Paypal", value: PaymentMethodType.Paypal },
-                { label: "Cash", value: PaymentMethodType.Cash },
-              ]}
-            />
-          </Stack>
-
-          {form.values.selectedPaymentMethod === PaymentMethodType.Iban && (
-            <>
-              <TextInput
-                radius={0}
-                variant="unstyled"
-                size="md"
-                label="Account Name"
-                placeholder="John Doe"
-                {...form.getInputProps("accountName")}
-              />
-              <Input.Wrapper label="IBAN" error={form.errors["paymentMethod.iban"]}>
-                <Input
-                  radius={0}
-                  variant="unstyled"
-                  size="md"
-                  placeholder="DE00 0000 0000 0000 0000 00"
-                  {...form.getInputProps("paymentMethod.iban")}
-                />
-              </Input.Wrapper>
-            </>
-          )}
-
-          {form.values.selectedPaymentMethod === PaymentMethodType.Paypal && (
-            <TextInput
-              radius={0}
-              variant="unstyled"
-              size="md"
-              label="Paypal Email / Account"
-              placeholder="@johndoe"
-              {...form.getInputProps("paymentMethod.paypal")}
-            />
-          )}
+          <PaymentForm form={form} />
         </Stack>
       </Carousel.Slide>
     </Modal>

--- a/src/components/UserSelectionModal.tsx
+++ b/src/components/UserSelectionModal.tsx
@@ -69,12 +69,17 @@ const UserSelectionModal = ({
       selectedPaymentMethod: PaymentMethodType.Iban,
       paymentMethod: { iban: "", paypal: "" },
     },
-    validate: (values) => ({
-      "paymentMethod.iban":
-        values.selectedPaymentMethod === PaymentMethodType.Iban
-          ? validateIban(values.paymentMethod.iban)
-          : null,
-    }),
+    validate: (values) => {
+      if (page === 1) {
+        return {
+          "paymentMethod.iban":
+            values.selectedPaymentMethod === PaymentMethodType.Iban
+              ? validateIban(values.paymentMethod.iban)
+              : null,
+        };
+      }
+      return {};
+    },
   });
 
   const hasPaymentDetails = (p: Participant): boolean => {

--- a/src/components/UserSelectionModal.tsx
+++ b/src/components/UserSelectionModal.tsx
@@ -21,6 +21,7 @@ import { useHover } from "@mantine/hooks";
 import { useUpdateParticipant } from "@/api";
 import Modal from "./Modal";
 import { getHashedSessionId, recordConsent } from "@/lib/consent";
+import { validateIban } from "@/lib/validateIban";
 
 type ParticipantItemProps = {
   participant: Participant;
@@ -70,6 +71,12 @@ const UserSelectionModal = ({
       selectedPaymentMethod: PaymentMethodType.Iban,
       paymentMethod: { iban: "", paypal: "" },
     },
+    validate: (values) => ({
+      "paymentMethod.iban":
+        values.selectedPaymentMethod === PaymentMethodType.Iban
+          ? validateIban(values.paymentMethod.iban)
+          : null,
+    }),
   });
 
   const hasPaymentDetails = (p: Participant): boolean => {
@@ -77,7 +84,7 @@ const UserSelectionModal = ({
       case PaymentMethodType.Cash:
         return true;
       case PaymentMethodType.Iban:
-        return p.paymentMethod.iban.trim().length > 0;
+        return validateIban(p.paymentMethod.iban) === null;
       case PaymentMethodType.Paypal:
         return p.paymentMethod.paypal.trim().length > 0;
       default:
@@ -99,6 +106,7 @@ const UserSelectionModal = ({
 
   const handleSave = async () => {
     if (!selectedParticipant?.id) return;
+    if (form.validate().hasErrors) return;
     const needsConsent =
       form.values.selectedPaymentMethod === PaymentMethodType.Iban ||
       form.values.selectedPaymentMethod === PaymentMethodType.Paypal;
@@ -224,7 +232,7 @@ const UserSelectionModal = ({
                 placeholder="John Doe"
                 {...form.getInputProps("accountName")}
               />
-              <Input.Wrapper label="IBAN">
+              <Input.Wrapper label="IBAN" error={form.errors["paymentMethod.iban"]}>
                 <Input
                   radius={0}
                   variant="unstyled"

--- a/src/components/ViewParticipantModal/index.tsx
+++ b/src/components/ViewParticipantModal/index.tsx
@@ -1,11 +1,12 @@
 import { Center } from "@mantine/core";
 import { useCounter } from "@mantine/hooks";
 import { useForm } from "@mantine/form";
-import { Participant } from "@/types";
+import { Participant, PaymentMethodType } from "@/types";
 import PageSetPayment from "../AddParticipantModal/components/PageSetPayment";
 import Modal from "../Modal";
 import { Carousel } from "@mantine/carousel";
 import { useUpdateParticipant } from "@/api";
+import { validateIban } from "@/lib/validateIban";
 
 type ViewParticipantModalProps = {
   participant: Participant;
@@ -31,6 +32,10 @@ const ViewParticipantModal = ({
           name:
             values.name.trim().length < 1
               ? "Person name must include at least 1 character"
+              : null,
+          "paymentMethod.iban":
+            values.selectedPaymentMethod === PaymentMethodType.Iban
+              ? validateIban(values.paymentMethod.iban)
               : null,
         };
       }

--- a/src/lib/validateIban.ts
+++ b/src/lib/validateIban.ts
@@ -1,0 +1,9 @@
+import { isValidIBAN, electronicFormatIBAN } from "ibantools";
+
+export function validateIban(raw: string): string | null {
+  const normalized = electronicFormatIBAN(raw.replace(/\s/g, "").toUpperCase());
+  if (!normalized || !isValidIBAN(normalized)) {
+    return "Invalid IBAN";
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Add `ibantools`-backed IBAN validation (mod-97 + country-specific length) across all payment forms
- Add `IbanInput` component — auto-spaces every 4 chars, blocks manual spaces, caps at 34 chars
- Extract `PaymentForm` shared component — replaces duplicated payment JSX in `PaymentDetailsModal`, `UserSelectionModal`, and `PageSetPayment`
- Fix mobile cursor refresh in `PaymentDetailsModal` by memoizing `footerContent` with `useCallback`
- Match Save button loading style (dots loader + `radius="xl"`) with rest of app

## Test plan

- [ ] Add participant with valid IBAN — validation passes
- [ ] Add participant with invalid IBAN — error shown, cannot proceed
- [ ] Type in IBAN field — spaces auto-inserted every 4 chars
- [ ] Try typing space in IBAN field — blocked
- [ ] Paste 34-char IBAN — capped correctly, formatted with spaces
- [ ] Edit payment details via `PaymentDetailsModal` — save works, loading dots shown
- [ ] Select participant in `UserSelectionModal` without payment details — prompted to enter, validation enforced
- [ ] Switch between IBAN / PayPal / Cash — correct fields shown/hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)