### PR TITLE
Add currency dropdown to group create/edit form

### DIFF
--- a/src/app/group/[groupId]/components/TabOverview.tsx
+++ b/src/app/group/[groupId]/components/TabOverview.tsx
@@ -6,9 +6,10 @@ import ViewDebtModal from "@/components/ViewDebtModal";
 
 type TabOverviewProps = {
   localUserId?: string | null;
+  currency?: string;
 };
 
-const TabOverview = ({ localUserId }: TabOverviewProps) => {
+const TabOverview = ({ localUserId, currency }: TabOverviewProps) => {
   const { groupId } = useParams<{ groupId: string }>();
   const { data, isPending } = useDebts(groupId);
 
@@ -51,13 +52,13 @@ const TabOverview = ({ localUserId }: TabOverviewProps) => {
           ) : (
             <>
               {myDebts.map((debt, i) => (
-                <ViewDebtModal key={`my-${i}`} debt={debt} />
+                <ViewDebtModal key={`my-${i}`} debt={debt} currency={currency} />
               ))}
               {owedToMe.map((debt, i) => (
-                <ViewDebtModal key={`owed-${i}`} debt={debt} />
+                <ViewDebtModal key={`owed-${i}`} debt={debt} currency={currency} />
               ))}
               {otherDebts.map((debt, i) => (
-                <ViewDebtModal key={`other-${i}`} debt={debt} />
+                <ViewDebtModal key={`other-${i}`} debt={debt} currency={currency} />
               ))}
             </>
           )}

--- a/src/app/group/[groupId]/components/TabTotalSpending.tsx
+++ b/src/app/group/[groupId]/components/TabTotalSpending.tsx
@@ -125,7 +125,7 @@ const TabTotalSpending = ({
                           {selected.participant.name}
                         </Text>
                         <Text size="sm" c="dimmed">
-                          <EuroNumberFormatter value={selected.total} /> paid
+                          <EuroNumberFormatter value={selected.total} currency={groupData.data?.expand.groupInfo.currency} /> paid
                         </Text>
                       </Stack>
                     </Center>
@@ -157,7 +157,7 @@ const TabTotalSpending = ({
                               }
                               rightSection={
                                 <Text fw={500} size="sm">
-                                  <EuroNumberFormatter value={e.amount} />
+                                  <EuroNumberFormatter value={e.amount} currency={groupData.data?.expand.groupInfo.currency} />
                                 </Text>
                               }
                               style={{ pointerEvents: "none" }}
@@ -178,7 +178,7 @@ const TabTotalSpending = ({
             <NavLink
               key={participant.id}
               label={participant.name}
-              description={<EuroNumberFormatter value={total} />}
+              description={<EuroNumberFormatter value={total} currency={groupData.data?.expand.groupInfo.currency} />}
               leftSection={
                 <UserAvatar size="md">
                   <Title order={3}>{participant.avatar.emoji}</Title>

--- a/src/app/group/[groupId]/components/TabTotalSpending.tsx
+++ b/src/app/group/[groupId]/components/TabTotalSpending.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mantine/core";
 import { useParams } from "next/navigation";
 import { useTransactions } from "@/api";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { CurrencyFormatter } from "@/components/NumberFormatter";
 import { ExpenseTransactionData, Participant, TotalSpendData } from "@/types";
 import { UseQueryResult } from "@tanstack/react-query";
 import { useDisclosure, useMediaQuery, useViewportSize } from "@mantine/hooks";
@@ -125,7 +125,7 @@ const TabTotalSpending = ({
                           {selected.participant.name}
                         </Text>
                         <Text size="sm" c="dimmed">
-                          <EuroNumberFormatter value={selected.total} currency={groupData.data?.expand.groupInfo.currency} /> paid
+                          <CurrencyFormatter value={selected.total} currency={groupData.data?.expand.groupInfo.currency} /> paid
                         </Text>
                       </Stack>
                     </Center>
@@ -157,7 +157,7 @@ const TabTotalSpending = ({
                               }
                               rightSection={
                                 <Text fw={500} size="sm">
-                                  <EuroNumberFormatter value={e.amount} currency={groupData.data?.expand.groupInfo.currency} />
+                                  <CurrencyFormatter value={e.amount} currency={groupData.data?.expand.groupInfo.currency} />
                                 </Text>
                               }
                               style={{ pointerEvents: "none" }}
@@ -178,7 +178,7 @@ const TabTotalSpending = ({
             <NavLink
               key={participant.id}
               label={participant.name}
-              description={<EuroNumberFormatter value={total} currency={groupData.data?.expand.groupInfo.currency} />}
+              description={<CurrencyFormatter value={total} currency={groupData.data?.expand.groupInfo.currency} />}
               leftSection={
                 <UserAvatar size="md">
                   <Title order={3}>{participant.avatar.emoji}</Title>

--- a/src/app/group/[groupId]/components/TabTransactions.tsx
+++ b/src/app/group/[groupId]/components/TabTransactions.tsx
@@ -105,7 +105,7 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
                   }
                   rightSection={
                     <Title order={5}>
-                      <EuroNumberFormatter value={trans.amount} />
+                      <EuroNumberFormatter value={trans.amount} currency={groupData.data?.expand.groupInfo.currency} />
                     </Title>
                   }
                   onClick={() =>
@@ -133,7 +133,7 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
                   }
                   rightSection={
                     <Title order={5}>
-                      <EuroNumberFormatter value={trans.amount} />
+                      <EuroNumberFormatter value={trans.amount} currency={groupData.data?.expand.groupInfo.currency} />
                     </Title>
                   }
                   onClick={() =>

--- a/src/app/group/[groupId]/components/TabTransactions.tsx
+++ b/src/app/group/[groupId]/components/TabTransactions.tsx
@@ -16,7 +16,7 @@ import UserAvatar from "@/components/UserAvatar";
 import { DateToCalendar } from "@/utils/date";
 import { useTransactions } from "@/api";
 import { useParams, useRouter } from "next/navigation";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { CurrencyFormatter } from "@/components/NumberFormatter";
 import AddEditTransactionModal from "@/components/AddEditTransactionModal";
 import { UseQueryResult } from "@tanstack/react-query";
 
@@ -105,7 +105,7 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
                   }
                   rightSection={
                     <Title order={5}>
-                      <EuroNumberFormatter value={trans.amount} currency={groupData.data?.expand.groupInfo.currency} />
+                      <CurrencyFormatter value={trans.amount} currency={groupData.data?.expand.groupInfo.currency} />
                     </Title>
                   }
                   onClick={() =>
@@ -133,7 +133,7 @@ const TabTransactions = ({ groupData, localUserId }: TabTransactionsProps) => {
                   }
                   rightSection={
                     <Title order={5}>
-                      <EuroNumberFormatter value={trans.amount} currency={groupData.data?.expand.groupInfo.currency} />
+                      <CurrencyFormatter value={trans.amount} currency={groupData.data?.expand.groupInfo.currency} />
                     </Title>
                   }
                   onClick={() =>

--- a/src/app/group/[groupId]/components/TopSummary.tsx
+++ b/src/app/group/[groupId]/components/TopSummary.tsx
@@ -94,7 +94,7 @@ const TopSummary = ({ selectedTab, groupData, localUserId }: TopSummaryProps) =>
                     order={2}
                     c={netBalance > 0 ? "green" : netBalance < 0 ? "red" : "dimmed"}
                   >
-                    <EuroNumberFormatter value={Math.abs(netBalance)} />
+                    <EuroNumberFormatter value={Math.abs(netBalance)} currency={data.expand.groupInfo.currency} />
                   </Title>
                 </Center>
                 <Center>
@@ -124,7 +124,7 @@ const TopSummary = ({ selectedTab, groupData, localUserId }: TopSummaryProps) =>
             </Center>
             <Center>
               <Title order={2}>
-                <EuroNumberFormatter value={data.sumExpenses ?? 0} />
+                <EuroNumberFormatter value={data.sumExpenses ?? 0} currency={data.expand.groupInfo.currency} />
               </Title>
             </Center>
           </Stack>

--- a/src/app/group/[groupId]/components/TopSummary.tsx
+++ b/src/app/group/[groupId]/components/TopSummary.tsx
@@ -13,7 +13,7 @@ import { TabType } from "./Tab";
 import { useParams } from "next/navigation";
 import { UseQueryResult } from "@tanstack/react-query";
 import ListParticipantsModal from "@/components/ListParticipantsModal";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { CurrencyFormatter } from "@/components/NumberFormatter";
 import EditGroupModal from "./EditGroupModal";
 import { useDebts } from "@/api";
 
@@ -94,7 +94,7 @@ const TopSummary = ({ selectedTab, groupData, localUserId }: TopSummaryProps) =>
                     order={2}
                     c={netBalance > 0 ? "green" : netBalance < 0 ? "red" : "dimmed"}
                   >
-                    <EuroNumberFormatter value={Math.abs(netBalance)} currency={data.expand.groupInfo.currency} />
+                    <CurrencyFormatter value={Math.abs(netBalance)} currency={data.expand.groupInfo.currency} />
                   </Title>
                 </Center>
                 <Center>
@@ -124,7 +124,7 @@ const TopSummary = ({ selectedTab, groupData, localUserId }: TopSummaryProps) =>
             </Center>
             <Center>
               <Title order={2}>
-                <EuroNumberFormatter value={data.sumExpenses ?? 0} currency={data.expand.groupInfo.currency} />
+                <CurrencyFormatter value={data.sumExpenses ?? 0} currency={data.expand.groupInfo.currency} />
               </Title>
             </Center>
           </Stack>

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -63,7 +63,7 @@ const GroupPage = () => {
           <Center>
             <Tab selectedTab={selectedTab} setSelectedTab={setSelectedTab} />
           </Center>
-          {selectedTab === TabType.Overview && <TabOverview localUserId={localUserId} />}
+          {selectedTab === TabType.Overview && <TabOverview localUserId={localUserId} currency={groupData.data?.expand.groupInfo.currency} />}
           {selectedTab === TabType.Transactions && (
             <TabTransactions groupData={groupData} localUserId={localUserId} />
           )}

--- a/src/app/group/[groupId]/transaction/components/ExpensePage.tsx
+++ b/src/app/group/[groupId]/transaction/components/ExpensePage.tsx
@@ -17,7 +17,7 @@ import { IconCash } from "@tabler/icons-react";
 import { IconUser } from "@tabler/icons-react";
 import { IconShare } from "@tabler/icons-react";
 import { SplitType } from "@/types";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { CurrencyFormatter } from "@/components/NumberFormatter";
 import DeleteButton from "./DeleteButton";
 import { useDeleteExpense } from "@/api";
 import AddEditTransactionModal from "@/components/AddEditTransactionModal";
@@ -102,7 +102,7 @@ const ExpensePage = () => {
             {data.name}
           </Title>
           <Title order={1} style={{ fontSize: rem(40) }}>
-            <EuroNumberFormatter value={data.amount} currency={data.expand.groupInfo.currency} />
+            <CurrencyFormatter value={data.amount} currency={data.expand.groupInfo.currency} />
           </Title>
           <Text c="dimmed" pb="xl">
             {dayjs(data.transactionDateTime).format("dddd, MMMM D, YYYY HH:mm")}
@@ -154,7 +154,7 @@ const ExpensePage = () => {
                           avatar={participant.avatar}
                           name={participant.name}
                           description={
-                            <EuroNumberFormatter
+                            <CurrencyFormatter
                               value={
                                 data.splitType !== SplitType.Equal && data.participantAmounts
                                   ? (data.participantAmounts[participant.id!] ?? 0)
@@ -172,7 +172,7 @@ const ExpensePage = () => {
                             avatar={participant.avatar}
                             name={participant.name}
                             description={
-                              <EuroNumberFormatter
+                              <CurrencyFormatter
                                 value={
                                   data.splitType !== SplitType.Equal && data.participantAmounts
                                     ? (data.participantAmounts[participant.id!] ?? 0)
@@ -197,7 +197,7 @@ const ExpensePage = () => {
                               key={participant.id}
                               avatar={participant.avatar}
                               name={participant.name}
-                              description={<EuroNumberFormatter value={0} currency={data.expand.groupInfo.currency} />}
+                              description={<CurrencyFormatter value={0} currency={data.expand.groupInfo.currency} />}
                             />
                           ))
                       : null

--- a/src/app/group/[groupId]/transaction/components/ExpensePage.tsx
+++ b/src/app/group/[groupId]/transaction/components/ExpensePage.tsx
@@ -102,7 +102,7 @@ const ExpensePage = () => {
             {data.name}
           </Title>
           <Title order={1} style={{ fontSize: rem(40) }}>
-            <EuroNumberFormatter value={data.amount} />
+            <EuroNumberFormatter value={data.amount} currency={data.expand.groupInfo.currency} />
           </Title>
           <Text c="dimmed" pb="xl">
             {dayjs(data.transactionDateTime).format("dddd, MMMM D, YYYY HH:mm")}
@@ -160,6 +160,7 @@ const ExpensePage = () => {
                                   ? (data.participantAmounts[participant.id!] ?? 0)
                                   : data.amountPerPerson
                               }
+                              currency={data.expand.groupInfo.currency}
                             />
                           }
                         />
@@ -177,6 +178,7 @@ const ExpensePage = () => {
                                     ? (data.participantAmounts[participant.id!] ?? 0)
                                     : data.amountPerPerson
                                 }
+                                currency={data.expand.groupInfo.currency}
                               />
                             }
                           />
@@ -195,7 +197,7 @@ const ExpensePage = () => {
                               key={participant.id}
                               avatar={participant.avatar}
                               name={participant.name}
-                              description={<EuroNumberFormatter value={0} />}
+                              description={<EuroNumberFormatter value={0} currency={data.expand.groupInfo.currency} />}
                             />
                           ))
                       : null

--- a/src/app/group/[groupId]/transaction/components/PaybackPage.tsx
+++ b/src/app/group/[groupId]/transaction/components/PaybackPage.tsx
@@ -95,7 +95,7 @@ const PaybackPage = () => {
             </Stack>
           </Group>
           <Title order={1} style={{ fontSize: rem(40) }}>
-            <EuroNumberFormatter value={data.amount} />
+            <EuroNumberFormatter value={data.amount} currency={data.expand.groupInfo.currency} />
           </Title>
           <Text c="dimmed" pb="xl">
             {dayjs(data.transactionDateTime).format("dddd, MMMM D, YYYY HH:mm")}

--- a/src/app/group/[groupId]/transaction/components/PaybackPage.tsx
+++ b/src/app/group/[groupId]/transaction/components/PaybackPage.tsx
@@ -12,7 +12,7 @@ import UserAvatar from "@/components/UserAvatar";
 import { useDeletePayback, usePayback } from "@/api";
 import dayjs from "dayjs";
 import { IconArrowNarrowRight } from "@tabler/icons-react";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { CurrencyFormatter } from "@/components/NumberFormatter";
 import DeleteButton from "./DeleteButton";
 import Metadata from "@/components/Metadata";
 const textTypeStyle: TextProps = {
@@ -95,7 +95,7 @@ const PaybackPage = () => {
             </Stack>
           </Group>
           <Title order={1} style={{ fontSize: rem(40) }}>
-            <EuroNumberFormatter value={data.amount} currency={data.expand.groupInfo.currency} />
+            <CurrencyFormatter value={data.amount} currency={data.expand.groupInfo.currency} />
           </Title>
           <Text c="dimmed" pb="xl">
             {dayjs(data.transactionDateTime).format("dddd, MMMM D, YYYY HH:mm")}

--- a/src/components/AddEditTransactionModal/components/PageSetAmount.tsx
+++ b/src/components/AddEditTransactionModal/components/PageSetAmount.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
 import { GroupData, TransactionFormValues } from "@/types";
-import { currencyToSymbol } from "@/utils/currency";
+import { currencyFormat } from "@/utils/currency";
 
 type PageSetAmountProps = {
   groupData: GroupData;
@@ -17,6 +17,7 @@ type PageSetAmountProps = {
 };
 
 const PageSetAmount = ({ form, groupData }: PageSetAmountProps) => {
+  const { symbol, decimalSeparator, thousandSeparator } = currencyFormat(groupData.currency);
   return (
     <Container>
       <Center>
@@ -36,15 +37,15 @@ const PageSetAmount = ({ form, groupData }: PageSetAmountProps) => {
           }}
           radius={0}
           variant="unstyled"
-          placeholder={`0,00${currencyToSymbol(groupData.currency)}`}
+          placeholder={`0${decimalSeparator}00${symbol}`}
           min={0}
           max={9999999}
           clampBehavior="strict"
-          suffix={currencyToSymbol(groupData.currency)}
+          suffix={symbol}
           // defaultValue={0}
           decimalScale={2}
-          decimalSeparator=","
-          thousandSeparator="."
+          decimalSeparator={decimalSeparator}
+          thousandSeparator={thousandSeparator}
           allowNegative={false}
           // size={rem(50)}
           // mb="md"

--- a/src/components/AddEditTransactionModal/components/PageSetAmount.tsx
+++ b/src/components/AddEditTransactionModal/components/PageSetAmount.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
 import { GroupData, TransactionFormValues } from "@/types";
+import { currencyToSymbol } from "@/utils/currency";
 
 type PageSetAmountProps = {
   groupData: GroupData;
@@ -35,11 +36,11 @@ const PageSetAmount = ({ form, groupData }: PageSetAmountProps) => {
           }}
           radius={0}
           variant="unstyled"
-          placeholder="0,00€"
+          placeholder={`0,00${currencyToSymbol(groupData.currency)}`}
           min={0}
           max={9999999}
           clampBehavior="strict"
-          suffix="€"
+          suffix={currencyToSymbol(groupData.currency)}
           // defaultValue={0}
           decimalScale={2}
           decimalSeparator=","

--- a/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
+++ b/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/types";
 import { useMediaQuery, useViewportSize } from "@mantine/hooks";
 import ParticipantAvatarHorizontal from "@/components/ParticipantAvatarHorizontal";
-import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { CurrencyFormatter } from "@/components/NumberFormatter";
 import { currencyToSymbol } from "@/utils/currency";
 import { useEffect } from "react";
 
@@ -236,7 +236,7 @@ const PageSetSplit = ({
                             name={participant.name}
                             description={
                               <Text lineClamp={2} ta="center">
-                                {EuroNumberFormatter({
+                                {CurrencyFormatter({
                                   value: calculateEqualSplit(),
                                   currency: groupData.currency,
                                 })}
@@ -278,7 +278,7 @@ const PageSetSplit = ({
                                           lineClamp={2}
                                           ta="center"
                                         >
-                                          {EuroNumberFormatter({
+                                          {CurrencyFormatter({
                                             value: calculatePartSplit(
                                               split.part || 0
                                             ),
@@ -448,7 +448,7 @@ const PageSetSplit = ({
                         name={participant.name}
                         // description={
                         //   <Text c="dimmed" lineClamp={2} ta="center">
-                        //     {EuroNumberFormatter({
+                        //     {CurrencyFormatter({
                         //       value: calculateEqualSplit(),
                         //     })}
                         //   </Text>
@@ -493,7 +493,7 @@ const PageSetSplit = ({
                                     }}
                                   ></Input>
                                   <Text c="dimmed" lineClamp={2} ta="center">
-                                    {EuroNumberFormatter({
+                                    {CurrencyFormatter({
                                       value: calculatePartSplit(
                                         split.part || 0
                                       ),
@@ -505,7 +505,7 @@ const PageSetSplit = ({
                           // <>
                           //   <Input value={}></Input>
                           //   <Text c="dimmed" lineClamp={2} ta="center">
-                          //     {EuroNumberFormatter({
+                          //     {CurrencyFormatter({
                           //       value: calculatePartSplit(participant.part),
                           //     })}
                           //   </Text>
@@ -528,7 +528,7 @@ const PageSetSplit = ({
                   fw={500}
                   c={calculateRemainingAmount() < -0.001 ? "red" : calculateRemainingAmount() < 0.001 ? "green" : undefined}
                 >
-                  {EuroNumberFormatter({ value: calculateRemainingAmount(), currency: groupData.currency })}
+                  {CurrencyFormatter({ value: calculateRemainingAmount(), currency: groupData.currency })}
                 </Text>
               </Group>
               {form.errors.splitAmountError && (

--- a/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
+++ b/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
@@ -26,7 +26,7 @@ import {
 import { useMediaQuery, useViewportSize } from "@mantine/hooks";
 import ParticipantAvatarHorizontal from "@/components/ParticipantAvatarHorizontal";
 import { CurrencyFormatter } from "@/components/NumberFormatter";
-import { currencyToSymbol } from "@/utils/currency";
+import { currencyFormat } from "@/utils/currency";
 import { useEffect } from "react";
 
 type PageSetSplitProps = {
@@ -45,6 +45,7 @@ const PageSetSplit = ({
   const isMobile = useMediaQuery("(max-width: 50em)") || false;
   const { height, width } = useViewportSize();
   const modalHeight = isMobile ? rem(height - 100) : rem(500);
+  const { symbol, decimalSeparator, thousandSeparator } = currencyFormat(groupData.currency);
   const theme = useMantineTheme();
   const computedColorScheme = useComputedColorScheme();
 
@@ -405,12 +406,12 @@ const PageSetSplit = ({
                                     min={0}
                                     max={9999999}
                                     clampBehavior="strict"
-                                    placeholder={`0,00${currencyToSymbol(groupData.currency)}`}
-                                    suffix={currencyToSymbol(groupData.currency)}
+                                    placeholder={`0${decimalSeparator}00${symbol}`}
+                                    suffix={symbol}
                                     variant="unstyled"
                                     decimalScale={2}
-                                    decimalSeparator=","
-                                    thousandSeparator="."
+                                    decimalSeparator={decimalSeparator}
+                                    thousandSeparator={thousandSeparator}
                                     allowNegative={false}
                                     value={split.amount ?? ""}
                                     onChange={(e) => {

--- a/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
+++ b/src/components/AddEditTransactionModal/components/PageSetSplit.tsx
@@ -26,6 +26,7 @@ import {
 import { useMediaQuery, useViewportSize } from "@mantine/hooks";
 import ParticipantAvatarHorizontal from "@/components/ParticipantAvatarHorizontal";
 import { EuroNumberFormatter } from "@/components/NumberFormatter";
+import { currencyToSymbol } from "@/utils/currency";
 import { useEffect } from "react";
 
 type PageSetSplitProps = {
@@ -237,6 +238,7 @@ const PageSetSplit = ({
                               <Text lineClamp={2} ta="center">
                                 {EuroNumberFormatter({
                                   value: calculateEqualSplit(),
+                                  currency: groupData.currency,
                                 })}
                               </Text>
                             }
@@ -280,6 +282,7 @@ const PageSetSplit = ({
                                             value: calculatePartSplit(
                                               split.part || 0
                                             ),
+                                            currency: groupData.currency,
                                           })}
                                         </Text>
                                       }
@@ -402,8 +405,8 @@ const PageSetSplit = ({
                                     min={0}
                                     max={9999999}
                                     clampBehavior="strict"
-                                    placeholder="0,00"
-                                    suffix="€"
+                                    placeholder={`0,00${currencyToSymbol(groupData.currency)}`}
+                                    suffix={currencyToSymbol(groupData.currency)}
                                     variant="unstyled"
                                     decimalScale={2}
                                     decimalSeparator=","
@@ -525,7 +528,7 @@ const PageSetSplit = ({
                   fw={500}
                   c={calculateRemainingAmount() < -0.001 ? "red" : calculateRemainingAmount() < 0.001 ? "green" : undefined}
                 >
-                  {EuroNumberFormatter({ value: calculateRemainingAmount() })}
+                  {EuroNumberFormatter({ value: calculateRemainingAmount(), currency: groupData.currency })}
                 </Text>
               </Group>
               {form.errors.splitAmountError && (

--- a/src/components/AddGroupModal/components/PageSetName.tsx
+++ b/src/components/AddGroupModal/components/PageSetName.tsx
@@ -5,8 +5,10 @@ import {
   Center,
   Container,
   Input,
+  NativeSelect,
   Space,
   Stack,
+  Text,
   TextInput,
   Textarea,
   Title,
@@ -44,6 +46,17 @@ const PageSetName = ({ form }: PageSetNameProps) => {
           // placeholder="Last weekend of March 2023"
           {...form.getInputProps("description")}
         />
+        <Center>
+          <Text fw={500} mr="sm">
+            Currency
+          </Text>
+          <NativeSelect
+            size="md"
+            variant="unstyled"
+            data={["EUR", "USD", "THB"]}
+            {...form.getInputProps("currency")}
+          />
+        </Center>
       </Stack>
     </Container>
   );

--- a/src/components/NumberFormatter.tsx
+++ b/src/components/NumberFormatter.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { NumberFormatter as MantineNumberFormatter } from "@mantine/core";
+import { currencyToSymbol } from "@/utils/currency";
 
 type NumberFormatterProps = {
   value: number | undefined;
+  currency?: string;
 };
 
-const EuroNumberFormatter = ({ value }: NumberFormatterProps) => {
+const EuroNumberFormatter = ({ value, currency = "EUR" }: NumberFormatterProps) => {
   return (
     <MantineNumberFormatter
-      suffix=" €"
+      suffix={` ${currencyToSymbol(currency)}`}
       value={value ? value : 0}
       thousandSeparator="."
       decimalSeparator=","

--- a/src/components/NumberFormatter.tsx
+++ b/src/components/NumberFormatter.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NumberFormatter as MantineNumberFormatter } from "@mantine/core";
-import { currencyToSymbol } from "@/utils/currency";
+import { currencyFormat } from "@/utils/currency";
 
 type NumberFormatterProps = {
   value: number | undefined;
@@ -8,12 +8,13 @@ type NumberFormatterProps = {
 };
 
 const CurrencyFormatter = ({ value, currency = "EUR" }: NumberFormatterProps) => {
+  const { symbol, decimalSeparator, thousandSeparator } = currencyFormat(currency);
   return (
     <MantineNumberFormatter
-      suffix={` ${currencyToSymbol(currency)}`}
+      suffix={` ${symbol}`}
       value={value ? value : 0}
-      thousandSeparator="."
-      decimalSeparator=","
+      thousandSeparator={thousandSeparator}
+      decimalSeparator={decimalSeparator}
       decimalScale={2}
       fixedDecimalScale
     />

--- a/src/components/NumberFormatter.tsx
+++ b/src/components/NumberFormatter.tsx
@@ -7,7 +7,7 @@ type NumberFormatterProps = {
   currency?: string;
 };
 
-const EuroNumberFormatter = ({ value, currency = "EUR" }: NumberFormatterProps) => {
+const CurrencyFormatter = ({ value, currency = "EUR" }: NumberFormatterProps) => {
   return (
     <MantineNumberFormatter
       suffix={` ${currencyToSymbol(currency)}`}
@@ -20,4 +20,4 @@ const EuroNumberFormatter = ({ value, currency = "EUR" }: NumberFormatterProps) 
   );
 };
 
-export { EuroNumberFormatter };
+export { CurrencyFormatter };

--- a/src/components/ViewDebtModal/index.tsx
+++ b/src/components/ViewDebtModal/index.tsx
@@ -58,10 +58,11 @@ const iconProps = {
 };
 type ViewDebtModalProps = {
   debt: DebtData;
+  currency?: string;
   // form: UseFormReturnType<any>;
 };
 
-const ViewDebtModal = ({ debt }: ViewDebtModalProps) => {
+const ViewDebtModal = ({ debt, currency = "EUR" }: ViewDebtModalProps) => {
   const { groupId } = useParams<{ groupId: string }>();
   const router = useRouter();
   const isMobile = useMediaQuery("(max-width: 50em)") || false;
@@ -149,7 +150,7 @@ const ViewDebtModal = ({ debt }: ViewDebtModalProps) => {
                     </Center>
                     <Center>
                       <Title order={1} style={{ fontSize: rem(40) }} pb="xl">
-                        <EuroNumberFormatter value={debt.amount} />
+                        <EuroNumberFormatter value={debt.amount} currency={currency} />
                       </Title>
                     </Center>
                     <Group gap={3} align="center">
@@ -299,7 +300,7 @@ const ViewDebtModal = ({ debt }: ViewDebtModalProps) => {
           }
           rightSection={
             <Title order={5}>
-              <EuroNumberFormatter value={debt.amount} />
+              <EuroNumberFormatter value={debt.amount} currency={currency} />
             </Title>
           }
         ></NavLink>

--- a/src/components/ViewDebtModal/index.tsx
+++ b/src/components/ViewDebtModal/index.tsx
@@ -20,7 +20,7 @@ import { IconChevronLeft } from "@tabler/icons-react";
 import { DebtData, PaybackFormValues, PaymentMethodType } from "@/types";
 import { useParams, useRouter } from "next/navigation";
 import { useViewportSize } from "@mantine/hooks";
-import { EuroNumberFormatter } from "../NumberFormatter";
+import { CurrencyFormatter } from "../NumberFormatter";
 import { IconArrowNarrowRight } from "@tabler/icons-react";
 import { IconUser } from "@tabler/icons-react";
 import { IconCash } from "@tabler/icons-react";
@@ -150,7 +150,7 @@ const ViewDebtModal = ({ debt, currency = "EUR" }: ViewDebtModalProps) => {
                     </Center>
                     <Center>
                       <Title order={1} style={{ fontSize: rem(40) }} pb="xl">
-                        <EuroNumberFormatter value={debt.amount} currency={currency} />
+                        <CurrencyFormatter value={debt.amount} currency={currency} />
                       </Title>
                     </Center>
                     <Group gap={3} align="center">
@@ -300,7 +300,7 @@ const ViewDebtModal = ({ debt, currency = "EUR" }: ViewDebtModalProps) => {
           }
           rightSection={
             <Title order={5}>
-              <EuroNumberFormatter value={debt.amount} currency={currency} />
+              <CurrencyFormatter value={debt.amount} currency={currency} />
             </Title>
           }
         ></NavLink>

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,8 +1,17 @@
-const symbolMap: Record<string, string> = {
-  EUR: "€",
-  USD: "$",
-  THB: "฿",
+type CurrencyFormat = {
+  symbol: string;
+  decimalSeparator: string;
+  thousandSeparator: string;
 };
 
+const formatMap: Record<string, CurrencyFormat> = {
+  EUR: { symbol: "€", decimalSeparator: ",", thousandSeparator: "." },
+  USD: { symbol: "$", decimalSeparator: ".", thousandSeparator: "," },
+  THB: { symbol: "฿", decimalSeparator: ".", thousandSeparator: "," },
+};
+
+export const currencyFormat = (currency: string): CurrencyFormat =>
+  formatMap[currency] ?? { symbol: currency, decimalSeparator: ".", thousandSeparator: "," };
+
 export const currencyToSymbol = (currency: string): string =>
-  symbolMap[currency] ?? currency;
+  currencyFormat(currency).symbol;

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,0 +1,8 @@
+const symbolMap: Record<string, string> = {
+  EUR: "€",
+  USD: "$",
+  THB: "฿",
+};
+
+export const currencyToSymbol = (currency: string): string =>
+  symbolMap[currency] ?? currency;


### PR DESCRIPTION
Places a NativeSelect (variant="unstyled") for EUR/USD/THB below the
description field in PageSetName, which is shared by both the create
and edit group modals.

https://claude.ai/code/session_01BG5NTWuS6yFrUixpdcnD4q